### PR TITLE
use imageName for repoName

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,8 +14,6 @@ variables:
     value: '$(Build.SourceVersion)'
   - name: imageName
     value: 'prod-bip/ssb/dapla/klass-subsets-api'
-  - name: repoName
-    value: 'eu.gcr.io/prod-bip/ssb/dapla/klass-subsets-api'
 
 jobs:
   - job: buildTestDockerBuildDockerPush
@@ -53,7 +51,7 @@ jobs:
         condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
         inputs:
           containerRegistry: gcrServiceConnection
-          repository: $(repoName)
+          repository: $(imageName)
           command: 'push'
           Dockerfile: 'Dockerfile'
           tags: |

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -3,7 +3,6 @@ package no.ssb.subsetsservice;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.coyote.Response;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.HttpClientErrorException;
@@ -49,6 +48,7 @@ public class SubsetsController {
             if (actualObj != null){
                 JsonNode idJN = actualObj.get("id");
                 String id = idJN.asText();
+                // TODO: check if subset already exists. Do not overwrite. new version instead.
                 return postTo(LDS_SUBSET_API, "/"+id, subsetsJson);
             }
         } catch (JsonProcessingException e) {
@@ -64,6 +64,7 @@ public class SubsetsController {
 
     @PutMapping(value = "/v1/subsets/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<String> putSubset(@PathVariable("id") String id, @RequestBody String subsetJson) {
+        // TODO: check if subset already exists. Do not overwrite. new version instead.
         return postTo(LDS_SUBSET_API, "/"+id, subsetJson);
     }
 


### PR DESCRIPTION
<img width="552" alt="eu gcr io should not be included" src="https://user-images.githubusercontent.com/28501510/82421524-6f7ad100-9a81-11ea-8170-9aeb45c99b50.PNG">

From this error when pushing it seems like `eu.gcr.io/` gets prepended to the "repoName" variable before pushing, which means `eu.gcr.io` should not be included in the "repoName", which means it should be the same as the imageName. I therefore use imageName as repoName when pushing the image to GCR.

This seems to be different from yesterday, where we had the problem that `eu.gcr.io/` was **not** prepended to the imageName like we expected it to be. In other words, it seems like it now behaves as we originally expected.