### PR TITLE
Versions and codes GET requests with date and interval parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ This API mimics the [KLASS Classifications API](https://data.ssb.no/api/klass/v1
 - `GET /v1/subsets/{id}/codes` to retrieve a list of the valid codes in the latest version of this subset. 
     - Optional query parameters "from" and "to" take dates on form "YYYY-MM-DD". When both are given, a list containing all codes that are valid in all versions from the "from" date to the "to" date will be returned.
 - `GET /v1/subsets/{id}/codesAt?date=YYYY-MM-DD` to retrieve a list of the codes valid on the given date
-- `GET /v1/versions/{id}/` to retrieve a list of all versions of this subset, in descending order (most recent first).
-- `GET /v1/versions/{id}/{version}` to retrieve a list of versions that start with {version}
+- `GET /v1/subsets/{id}/versions` to retrieve a list of all versions of this subset, in descending order (most recent first).
+- `GET /v1/subsets/{id}/versions/{version}` to retrieve a list of versions that start with {version}
 
 ### Misc
 In addition, we support getting the subset schema at "/v1/subsets?schema"

--- a/README.md
+++ b/README.md
@@ -9,10 +9,18 @@ The goal is to replace the existing Node + Express implementation, which can be 
 
 # API documentation
 
-The core functionality of the API:
-- GET and POST requests to "/v1/subsets". (GET gets all subsets, POST posts a single subset. The ID of the subset is found inside the JSON)
-- GET and PUT requests to "/v1/subsets/{id}" to retrieve or change a subset with a specific id.
+This API mimics the KLASS Classifications API as closely as is reasonable.
 
+### Core functionality
+- GET and POST `/v1/subsets`. (GET gets all subsets, POST posts a single subset. The ID of the subset is found inside the JSON)
+- GET and PUT `/v1/subsets/{id}` to retrieve or change a subset with a specific id.
+- `GET /v1/subsets/{id}/codes` to retrieve a list of the valid codes in the latest version of this subset. 
+    - Optional query parameters "from" and "to" take dates on form "YYYY-MM-DD". When both are given, a list containing all codes that are valid in all versions from the "from" date to the "to" date will be returned.
+- `GET /v1/subsets/{id}/codesAt?date=YYYY-MM-DD` to retrieve a list of the codes valid on the given date
+- `GET /v1/versions/{id}/` to retrieve a list of all versions of this subset, in descending order (most recent first).
+- `GET /v1/versions/{id}/{version}` to retrieve a list of versions that start with {version}
+
+### Misc
 In addition, we support getting the subset schema at "/v1/subsets?schema"
 And routing GET requests for codes to Klass codes API at "/v1/codes" or "/v1/codes/{id}"
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The goal is to replace the existing Node + Express implementation, which can be 
 
 # API documentation
 
-This API mimics the KLASS Classifications API as closely as is reasonable.
+This API mimics the [KLASS Classifications API](https://data.ssb.no/api/klass/v1/api-guide.html) as closely as is reasonable.
 
 ### Core functionality
 - GET and POST `/v1/subsets`. (GET gets all subsets, POST posts a single subset. The ID of the subset is found inside the JSON)

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -69,7 +69,7 @@ public class SubsetsController {
         return getFrom(LDS_SUBSET_API, "/"+id);
     }
 
-    @GetMapping("/v1/versions/{id}")
+    @GetMapping("/v1/subsets/{id}/versions")
     public ResponseEntity<String> getVersions(@PathVariable("id") String id) {
         return getFrom(LDS_SUBSET_API, "/"+id+"?timeline");
     }
@@ -82,7 +82,7 @@ public class SubsetsController {
      * @param version
      * @return
      */
-    @GetMapping("/v1/versions/{id}/{version}")
+    @GetMapping("/v1/subsets/{id}/versions/{version}")
     public ResponseEntity<JsonNode> getVersion(@PathVariable("id") String id, @PathVariable("version") String version) {
         ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/"+id+"?timeline");
         ObjectMapper mapper = new ObjectMapper();
@@ -128,8 +128,12 @@ public class SubsetsController {
             try {
                 JsonNode responseBodyJSON = mapper.readTree(ldsRE.getBody());
                 if (responseBodyJSON != null){
-                    JsonNode codes = responseBodyJSON.get("codes");
-                    return new ResponseEntity<>(codes, HttpStatus.OK);
+                    ArrayNode codes = (ArrayNode) responseBodyJSON.get("codes");
+                    ArrayNode urnArray = mapper.createArrayNode();
+                    for (int i = 0; i < codes.size(); i++) {
+                        urnArray.add(codes.get(i).get("urn").asText());
+                    }
+                    return new ResponseEntity<>(urnArray, HttpStatus.OK);
                 }
                 return new ResponseEntity<>(HttpStatus.NOT_FOUND);
             } catch (JsonProcessingException e) {

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -201,18 +201,22 @@ public class SubsetsController {
         return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
 
+    /**
+     * Returns all codes of the subset version that is valid on the given date.
+     * Assumes only one subset is valid on any given date, with no overlap of start/end date.
+     * @param id
+     * @param date
+     * @return
+     */
     @GetMapping("/v1/subsets/{id}/codesAt")
     public ResponseEntity<JsonNode> getSubsetCodesAt(@PathVariable("id") String id, @RequestParam String date) {
         ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/"+id+"?timeline");
-        //TODO: find version that is valid at date
-        //For each version, descending: if 'date' is at or after the version's 'validFrom', return the version's code list
         ObjectMapper mapper = new ObjectMapper();
         try {
             JsonNode responseBodyJSON = mapper.readTree(ldsRE.getBody());
             if (responseBodyJSON != null){
                 if (responseBodyJSON.isArray()) {
                     ArrayNode arrayNode = (ArrayNode) responseBodyJSON;
-                    JsonNode prev;
                     for (int i = 0; i < arrayNode.size(); i++) {
                         JsonNode version = arrayNode.get(i).get("document");
                         String entryValidFrom = version.get("validFrom").asText();

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -94,9 +94,20 @@ public class SubsetsController {
     }
 
     @GetMapping("/v1/subsets/{id}/codes")
-    public ResponseEntity<String> getSubsetCodes(@PathVariable("id") String id) {
+    public ResponseEntity<JsonNode> getSubsetCodes(@PathVariable("id") String id) {
         ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/"+id);
-        return ldsRE; //TODO: Replace with a new RE containing a list of the codes only
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            JsonNode responseBodyJSON = mapper.readTree(ldsRE.getBody());
+            if (responseBodyJSON != null){
+                JsonNode codes = responseBodyJSON.get("codes");
+                return new ResponseEntity<>(codes, HttpStatus.OK);
+            }
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
 
     @GetMapping("/v1/subsets/{id}/codes?from={fromDate}&to={toDate}")

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -76,7 +76,8 @@ public class SubsetsController {
 
     /**
      * Get a list of versions of a subset that starts with {versions}.
-     * So if {versions} is "1.0", then 1.0.1, 1.0.2, 1.0.3 etc will be returned
+     * So if {versions} is "1.0", then 1.0.0, 1.0.1, 1.0.2 etc will be returned.
+     * If {versions} is "1.0.1", then a list with a single item (1.0.1) will be returned
      * @param id
      * @param version
      * @return

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -17,7 +17,7 @@ public class SubsetsController {
     static final String LDS_LOCAL = "http://localhost:9090/ns/ClassificationSubset";
     private static String LDS_SUBSET_API = "";
 
-    private static final String KLASS_CODES_API = "https://data.ssb.no/api/klass/v1/classifications";
+    private static final String KLASS_CLASSIFICATIONS_API = "https://data.ssb.no/api/klass/v1/classifications";
 
     private static final boolean prod = false;
 
@@ -62,6 +62,42 @@ public class SubsetsController {
         return getFrom(LDS_SUBSET_API, "/"+id);
     }
 
+    @GetMapping("/v1/versions/{id}")
+    public ResponseEntity<String> getVersions(@PathVariable("id") String id) {
+        return getFrom(LDS_SUBSET_API, "/"+id+"?timeline");
+    }
+
+    @GetMapping("/v1/versions/{id}/{version}")
+    public ResponseEntity<String> getVersion(@PathVariable("id") String id, @PathVariable("version") String version) {
+        ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/"+id+"?timeline");
+        //TODO: Get a specific version by name on form "1.0.0", by looping through timeline
+        return ldsRE;
+    }
+
+    @GetMapping("/v1/subsets/{id}/codes")
+    public ResponseEntity<String> getSubsetCodes(@PathVariable("id") String id) {
+        ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/"+id);
+        return ldsRE; //TODO: Replace with a new RE containing a list of the codes only
+    }
+
+    @GetMapping("/v1/subsets/{id}/codes?from={fromDate}&to={toDate}")
+    public ResponseEntity<String> getSubsetCodes(@PathVariable("id") String id, @PathVariable("fromDate") String fromDate, @PathVariable("toDate") String toDate) {
+        ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/"+id+"?timeline");
+        //TODO: find intersection of valid codes for each version that is valid in the range.
+        //Step 1: Add all codes from all versions to a Hashmap, incrementing by 1 every time it is added.
+        //Step 2: Check each code in the map. If it has a value equal to the total number of versions, add it to the return list.
+        //Step 3: Return list of codes.
+        return ldsRE;
+    }
+
+    @GetMapping("/v1/subsets/{id}/codesAt?date={date}")
+    public ResponseEntity<String> getSubsetCodesAt(@PathVariable("id") String id, @PathVariable("date") String date) {
+        ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/"+id+"?timeline");
+        //TODO: find version that is valid at date
+        //For each version, descending: if 'date' is at or after the version's 'validFrom', return the version's code list
+        return ldsRE;
+    }
+
     @PutMapping(value = "/v1/subsets/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<String> putSubset(@PathVariable("id") String id, @RequestBody String subsetJson) {
         // TODO: check if subset already exists. Do not overwrite. new version instead.
@@ -73,14 +109,14 @@ public class SubsetsController {
         return getFrom(LDS_SUBSET_API,"/?schema");
     }
 
-    @GetMapping("/v1/codes")
-    public ResponseEntity<String> getCodes(){
-        return getFrom(KLASS_CODES_API, ".json");
+    @GetMapping("/v1/classifications")
+    public ResponseEntity<String> getClassifications(){
+        return getFrom(KLASS_CLASSIFICATIONS_API, ".json");
     }
 
-    @GetMapping("/v1/codes/{id}")
-    public ResponseEntity<String> getCode(@PathVariable("id") String id){
-        return getFrom(KLASS_CODES_API, "/"+id+".json");
+    @GetMapping("/v1/classifications/{id}")
+    public ResponseEntity<String> getClassification(@PathVariable("id") String id){
+        return getFrom(KLASS_CLASSIFICATIONS_API, "/"+id+".json");
     }
 
     static ResponseEntity<String> getFrom(String apiBase, String additional)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+logging.level.no.ssb.subsetsservice=INFO

--- a/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
@@ -1,6 +1,8 @@
 package no.ssb.subsetsservice;
 
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
 
@@ -13,7 +15,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 @SpringBootTest
 class SubsetsServiceApplicationTests {
 
+	private static final Logger LOG = LoggerFactory.getLogger(SubsetsServiceApplicationTests.class);
 	String ldsURL = SubsetsController.LDS_LOCAL;
+
+	@Test
+	void logTest(){
+		LOG.trace("TRACE");
+		LOG.debug("DEBUG");
+		LOG.info("INFO");
+		LOG.warn("WARN");
+		LOG.error("ERROR");
+	}
 
 	@Test
 	void postToLDSLocal() {


### PR DESCRIPTION
This PR implements retrieval of 
- all existing versions of a subset, 
- a specific versions of a subset, 
- all subsubversions (i.e "1.0.0") of a major version or subversion ("1", or "1.0") of a subset, 
- all codes valid on a given date, 
- all codes valid in the entirety of a a given interval

The API mimics the [KLASS Classifications API](https://data.ssb.no/api/klass/v1/api-guide.html) as closely as is reasonable:

- `GET /v1/subsets/{id}/codes` to retrieve a list of the valid codes in the latest version of this subset. 
    - Optional query parameters "from" and "to" take dates on form "YYYY-MM-DD". When both are given, a list containing all codes that are valid in all versions from the "from" date to the "to" date will be returned.
- `GET /v1/subsets/{id}/codesAt?date=YYYY-MM-DD` to retrieve a list of the codes valid on the given date
- `GET /v1/versions/{id}/` to retrieve a list of all versions of this subset, in descending order (most recent first).
- `GET /v1/versions/{id}/{version}` to retrieve a list of versions that start with {version}

The README has also been updated to reflect these changes.