### PR TITLE
validate parameters and ensure JSON on PUT/POST bodies

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -24,16 +24,18 @@ public class SubsetsController {
     static final String LDS_LOCAL = "http://localhost:9090/ns/ClassificationSubset";
     private static String LDS_SUBSET_API = "";
 
-    private static final String KLASS_CLASSIFICATIONS_API = "https://data.ssb.no/api/klass/v1/classifications";
+    private static String KLASS_CLASSIFICATIONS_API = "https://data.ssb.no/api/klass/v1/classifications";
 
     private static final boolean prod = false;
 
     public SubsetsController(){
         if (prod){
-            LDS_SUBSET_API = LDS_PROD;
+            String lds = System.getenv().getOrDefault("API_LDS", LDS_PROD);
+            LDS_SUBSET_API = lds;
         } else {
             LDS_SUBSET_API = LDS_LOCAL;
         }
+        KLASS_CLASSIFICATIONS_API = System.getenv().getOrDefault("API_KLASS", KLASS_CLASSIFICATIONS_API);
     }
 
     @GetMapping("/v1/subsets")
@@ -48,18 +50,12 @@ public class SubsetsController {
      * @return
      */
     @PostMapping("/v1/subsets")
-    public ResponseEntity<String> postSubset(@RequestBody String subsetsJson) {
-        ObjectMapper mapper = new ObjectMapper();
-        try {
-            JsonNode actualObj = mapper.readTree(subsetsJson);
-            if (actualObj != null){
-                JsonNode idJN = actualObj.get("id");
-                String id = idJN.asText();
-                // TODO: check if subset already exists. Do not overwrite. new version instead.
-                return postTo(LDS_SUBSET_API, "/"+id, subsetsJson);
-            }
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
+    public ResponseEntity<String> postSubset(@RequestBody JsonNode subsetsJson) {
+        if (subsetsJson != null) {
+            JsonNode idJN = subsetsJson.get("id");
+            String id = idJN.asText();
+            // TODO: check if subset already exists. Do not overwrite. new version instead.
+            return postTo(LDS_SUBSET_API, "/" + id, subsetsJson);
         }
         return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
@@ -84,27 +80,29 @@ public class SubsetsController {
      */
     @GetMapping("/v1/subsets/{id}/versions/{version}")
     public ResponseEntity<JsonNode> getVersion(@PathVariable("id") String id, @PathVariable("version") String version) {
-        ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/"+id+"?timeline");
-        ObjectMapper mapper = new ObjectMapper();
-        try {
-            JsonNode responseBodyJSON = mapper.readTree(ldsRE.getBody());
-            if (responseBodyJSON != null){
-                if (responseBodyJSON.isArray()) {
-                    ArrayNode responseBodyArrayNode = (ArrayNode) responseBodyJSON;
-                    ArrayNode returnVersionsArrayNode = mapper.createArrayNode();
-                    for (int i = 0; i < responseBodyArrayNode.size(); i++) {
-                        JsonNode arrayEntry = responseBodyArrayNode.get(i).get("document");
-                        String subsetVersion = arrayEntry.get("version").asText();
-                        if (subsetVersion.startsWith(version)){
-                            returnVersionsArrayNode.add(arrayEntry);
+        if (Utils.isClean(id) && Utils.isVersion(version)){
+            ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/"+id+"?timeline");
+            ObjectMapper mapper = new ObjectMapper();
+            try {
+                JsonNode responseBodyJSON = mapper.readTree(ldsRE.getBody());
+                if (responseBodyJSON != null){
+                    if (responseBodyJSON.isArray()) {
+                        ArrayNode responseBodyArrayNode = (ArrayNode) responseBodyJSON;
+                        ArrayNode returnVersionsArrayNode = mapper.createArrayNode();
+                        for (int i = 0; i < responseBodyArrayNode.size(); i++) {
+                            JsonNode arrayEntry = responseBodyArrayNode.get(i).get("document");
+                            String subsetVersion = arrayEntry.get("version").asText();
+                            if (subsetVersion.startsWith(version)){
+                                returnVersionsArrayNode.add(arrayEntry);
+                            }
                         }
+                        return new ResponseEntity<>(returnVersionsArrayNode, HttpStatus.OK);
                     }
-                    return new ResponseEntity<>(returnVersionsArrayNode, HttpStatus.OK);
                 }
+                return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
             }
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
         }
         return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
@@ -121,86 +119,90 @@ public class SubsetsController {
      */
     @GetMapping("/v1/subsets/{id}/codes")
     public ResponseEntity<JsonNode> getSubsetCodes(@PathVariable("id") String id, @RequestParam(required = false) String from, @RequestParam(required = false) String to) {
-        if (from == null || to == null){
-            LOG.debug("getting all codes of the latest/current version of subset "+id);
-            ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/"+id);
-            ObjectMapper mapper = new ObjectMapper();
-            try {
-                JsonNode responseBodyJSON = mapper.readTree(ldsRE.getBody());
-                if (responseBodyJSON != null){
-                    ArrayNode codes = (ArrayNode) responseBodyJSON.get("codes");
-                    ArrayNode urnArray = mapper.createArrayNode();
-                    for (int i = 0; i < codes.size(); i++) {
-                        urnArray.add(codes.get(i).get("urn").asText());
+        if (Utils.isClean(id)){
+            if (from == null || to == null){
+                LOG.debug("getting all codes of the latest/current version of subset "+id);
+                ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/"+id);
+                ObjectMapper mapper = new ObjectMapper();
+                try {
+                    JsonNode responseBodyJSON = mapper.readTree(ldsRE.getBody());
+                    if (responseBodyJSON != null){
+                        ArrayNode codes = (ArrayNode) responseBodyJSON.get("codes");
+                        ArrayNode urnArray = mapper.createArrayNode();
+                        for (int i = 0; i < codes.size(); i++) {
+                            urnArray.add(codes.get(i).get("urn").asText());
+                        }
+                        return new ResponseEntity<>(urnArray, HttpStatus.OK);
                     }
-                    return new ResponseEntity<>(urnArray, HttpStatus.OK);
+                    return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+                } catch (JsonProcessingException e) {
+                    e.printStackTrace();
                 }
-                return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-            } catch (JsonProcessingException e) {
-                e.printStackTrace();
+                return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
             }
-            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-        }
 
-        // If a date interval is specified using 'from' and 'to' query parameters
-        ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/"+id+"?timeline");
-        LOG.debug("Getting valid codes of subset "+id+" from date "+from+" to date "+to);
-        ObjectMapper mapper = new ObjectMapper();
-        Map<String,Integer> codeMap = new HashMap<>();
-        int nrOfVersions;
-        try {
-            JsonNode responseBodyJSON = mapper.readTree(ldsRE.getBody());
-            if (responseBodyJSON != null){
-                if (responseBodyJSON.isArray()) {
-                    ArrayNode versionsArrayNode = (ArrayNode) responseBodyJSON;
-                    nrOfVersions = versionsArrayNode.size();
-                    LOG.debug("Nr of versions: "+nrOfVersions);
-                    JsonNode firstVersion = versionsArrayNode.get(versionsArrayNode.size()-1).get("document");
-                    JsonNode lastVersion = versionsArrayNode.get(0).get("document");
-                    ArrayNode intersectionValidCodesInIntervalArrayNode = mapper.createArrayNode();
-                    // Check if first version includes fromDate, and last version includes toDate. If not, then return an empty list.
-                    String firstVersionValidFromString = firstVersion.get("validFrom").textValue().split("T")[0];
-                    String lastVersionValidUntilString = lastVersion.get("validUntil").textValue().split("T")[0];
-                    LOG.debug("First version valid from: "+firstVersionValidFromString);
-                    LOG.debug("Last version valid until: "+lastVersionValidUntilString);
-                    boolean isFirstValidAtOrBeforeFromDate = firstVersionValidFromString.compareTo(from) <= 0;
-                    LOG.debug("isFirstValidAtOrBeforeFromDate? "+ isFirstValidAtOrBeforeFromDate);
-                    boolean isLastValidAtOrAfterToDate = lastVersionValidUntilString.compareTo(to) >= 0;
-                    LOG.debug("isLastValidAtOrAfterToDate? "+isLastValidAtOrAfterToDate);
-                    if (isFirstValidAtOrBeforeFromDate && isLastValidAtOrAfterToDate){
-                        for (int i = 0; i < versionsArrayNode.size(); i++) {
-                            // if this version has any overlap with the valid interval . . .
-                            JsonNode arrayEntry = versionsArrayNode.get(i);
-                            JsonNode subset = arrayEntry.get("document");
-                            String validFromDateString = subset.get("validFrom").textValue().split("T")[0];
-                            String validUntilDateString = subset.get("validUntil").textValue().split("T")[0];
-                            if (validUntilDateString.compareTo(from) > 0 || validFromDateString.compareTo(to) < 0){
-                                LOG.debug("Version "+subset.get("version")+" is valid in the interval, so codes will be added to map");
-                                // . . . using each code in this version as key, increment corresponding integer value in map
-                                JsonNode codes = arrayEntry.get("document").get("codes");
-                                ArrayNode codesArrayNode = (ArrayNode) codes;
-                                LOG.debug("There are "+codesArrayNode.size()+" codes in this version");
-                                for (int i1 = 0; i1 < codesArrayNode.size(); i1++) {
-                                    String codeURN = codesArrayNode.get(i1).get("urn").asText();
-                                    codeMap.merge(codeURN, 1, Integer::sum);
+            if (Utils.isYearMonthDay(from) && Utils.isYearMonthDay(to)) {
+                // If a date interval is specified using 'from' and 'to' query parameters
+                ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/" + id + "?timeline");
+                LOG.debug(String.format("Getting valid codes of subset %s from date %s to date %s", id, from, to));
+                ObjectMapper mapper = new ObjectMapper();
+                Map<String, Integer> codeMap = new HashMap<>();
+                int nrOfVersions;
+                try {
+                    JsonNode responseBodyJSON = mapper.readTree(ldsRE.getBody());
+                    if (responseBodyJSON != null) {
+                        if (responseBodyJSON.isArray()) {
+                            ArrayNode versionsArrayNode = (ArrayNode) responseBodyJSON;
+                            nrOfVersions = versionsArrayNode.size();
+                            LOG.debug("Nr of versions: " + nrOfVersions);
+                            JsonNode firstVersion = versionsArrayNode.get(versionsArrayNode.size() - 1).get("document");
+                            JsonNode lastVersion = versionsArrayNode.get(0).get("document");
+                            ArrayNode intersectionValidCodesInIntervalArrayNode = mapper.createArrayNode();
+                            // Check if first version includes fromDate, and last version includes toDate. If not, then return an empty list.
+                            String firstVersionValidFromString = firstVersion.get("validFrom").textValue().split("T")[0];
+                            String lastVersionValidUntilString = lastVersion.get("validUntil").textValue().split("T")[0];
+                            LOG.debug("First version valid from: " + firstVersionValidFromString);
+                            LOG.debug("Last version valid until: " + lastVersionValidUntilString);
+                            boolean isFirstValidAtOrBeforeFromDate = firstVersionValidFromString.compareTo(from) <= 0;
+                            LOG.debug("isFirstValidAtOrBeforeFromDate? " + isFirstValidAtOrBeforeFromDate);
+                            boolean isLastValidAtOrAfterToDate = lastVersionValidUntilString.compareTo(to) >= 0;
+                            LOG.debug("isLastValidAtOrAfterToDate? " + isLastValidAtOrAfterToDate);
+                            if (isFirstValidAtOrBeforeFromDate && isLastValidAtOrAfterToDate) {
+                                for (int i = 0; i < versionsArrayNode.size(); i++) {
+                                    // if this version has any overlap with the valid interval . . .
+                                    JsonNode arrayEntry = versionsArrayNode.get(i);
+                                    JsonNode subset = arrayEntry.get("document");
+                                    String validFromDateString = subset.get("validFrom").textValue().split("T")[0];
+                                    String validUntilDateString = subset.get("validUntil").textValue().split("T")[0];
+                                    if (validUntilDateString.compareTo(from) > 0 || validFromDateString.compareTo(to) < 0) {
+                                        LOG.debug("Version " + subset.get("version") + " is valid in the interval, so codes will be added to map");
+                                        // . . . using each code in this version as key, increment corresponding integer value in map
+                                        JsonNode codes = arrayEntry.get("document").get("codes");
+                                        ArrayNode codesArrayNode = (ArrayNode) codes;
+                                        LOG.debug("There are " + codesArrayNode.size() + " codes in this version");
+                                        for (int i1 = 0; i1 < codesArrayNode.size(); i1++) {
+                                            String codeURN = codesArrayNode.get(i1).get("urn").asText();
+                                            codeMap.merge(codeURN, 1, Integer::sum);
+                                        }
+                                    }
+                                }
+                                // Only return codes that were in every version in the interval, (=> they were always valid)
+                                for (String key : codeMap.keySet()) {
+                                    int value = codeMap.get(key);
+                                    LOG.trace("key:" + key + " value:" + value);
+                                    if (value == nrOfVersions)
+                                        intersectionValidCodesInIntervalArrayNode.add(key);
                                 }
                             }
-                        }
-                        // Only return codes that were in every version in the interval, (=> they were always valid)
-                        for (String key : codeMap.keySet()){
-                            int value = codeMap.get(key);
-                            LOG.trace("key:"+key+" value:"+value);
-                            if (value == nrOfVersions)
-                                intersectionValidCodesInIntervalArrayNode.add(key);
+                            LOG.debug("nr of valid codes: " + intersectionValidCodesInIntervalArrayNode.size());
+                            return new ResponseEntity<>(intersectionValidCodesInIntervalArrayNode, HttpStatus.OK);
                         }
                     }
-                    LOG.debug("nr of valid codes: "+intersectionValidCodesInIntervalArrayNode.size());
-                    return new ResponseEntity<>(intersectionValidCodesInIntervalArrayNode, HttpStatus.OK);
+                    return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+                } catch (JsonProcessingException e) {
+                    e.printStackTrace();
                 }
             }
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
         }
         return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
@@ -214,34 +216,38 @@ public class SubsetsController {
      */
     @GetMapping("/v1/subsets/{id}/codesAt")
     public ResponseEntity<JsonNode> getSubsetCodesAt(@PathVariable("id") String id, @RequestParam String date) {
-        ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/"+id+"?timeline");
-        ObjectMapper mapper = new ObjectMapper();
-        try {
-            JsonNode responseBodyJSON = mapper.readTree(ldsRE.getBody());
-            if (responseBodyJSON != null){
-                if (responseBodyJSON.isArray()) {
-                    ArrayNode arrayNode = (ArrayNode) responseBodyJSON;
-                    for (int i = 0; i < arrayNode.size(); i++) {
-                        JsonNode version = arrayNode.get(i).get("document");
-                        String entryValidFrom = version.get("validFrom").asText();
-                        String entryValidUntil = version.get("validUntil").asText();
-                        if (entryValidFrom.compareTo(date) <= 0 && entryValidUntil.compareTo(date) >= 0 ){
-                            return new ResponseEntity<>(version.get("codes"), HttpStatus.OK);
+        if (Utils.isClean(id) && Utils.isYearMonthDay(date)){
+            ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/"+id+"?timeline");
+            ObjectMapper mapper = new ObjectMapper();
+            try {
+                JsonNode responseBodyJSON = mapper.readTree(ldsRE.getBody());
+                if (responseBodyJSON != null){
+                    if (responseBodyJSON.isArray()) {
+                        ArrayNode arrayNode = (ArrayNode) responseBodyJSON;
+                        for (int i = 0; i < arrayNode.size(); i++) {
+                            JsonNode version = arrayNode.get(i).get("document");
+                            String entryValidFrom = version.get("validFrom").asText();
+                            String entryValidUntil = version.get("validUntil").asText();
+                            if (entryValidFrom.compareTo(date) <= 0 && entryValidUntil.compareTo(date) >= 0 ){
+                                return new ResponseEntity<>(version.get("codes"), HttpStatus.OK);
+                            }
                         }
+                        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
                     }
-                    return new ResponseEntity<>(HttpStatus.NOT_FOUND);
                 }
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
             }
-        } catch (JsonProcessingException e) {
-            e.printStackTrace();
         }
         return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
 
     @PutMapping(value = "/v1/subsets/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<String> putSubset(@PathVariable("id") String id, @RequestBody String subsetJson) {
+    public ResponseEntity<String> putSubset(@PathVariable("id") String id, @RequestBody JsonNode subsetJson) {
         // TODO: check if subset already exists. Do not overwrite. new version instead.
-        return postTo(LDS_SUBSET_API, "/"+id, subsetJson);
+        if (Utils.isClean(id))
+            return postTo(LDS_SUBSET_API, "/"+id, subsetJson);
+        return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
 
     @GetMapping("/v1/subsets?schema")
@@ -256,7 +262,9 @@ public class SubsetsController {
 
     @GetMapping("/v1/classifications/{id}")
     public ResponseEntity<String> getClassification(@PathVariable("id") String id){
-        return getFrom(KLASS_CLASSIFICATIONS_API, "/"+id+".json");
+        if (Utils.isClean(id))
+            return getFrom(KLASS_CLASSIFICATIONS_API, "/"+id+".json");
+        return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
 
     static ResponseEntity<String> getFrom(String apiBase, String additional)
@@ -270,17 +278,17 @@ public class SubsetsController {
         }
     }
 
-    static ResponseEntity<String> postTo(String apiBase, String additional, String json){
+    static ResponseEntity<String> postTo(String apiBase, String additional, JsonNode json){
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
-        HttpEntity<String> request = new HttpEntity<>(json, headers);
+        HttpEntity<JsonNode> request = new HttpEntity<>(json, headers);
         ResponseEntity<String> response = new RestTemplate().postForEntity(apiBase+additional, request, String.class);
         System.out.println("POST to "+apiBase+additional+" - Status: "+response.getStatusCodeValue()+" "+response.getStatusCode().name());
         return response;
     }
 
-    static ResponseEntity<String> putTo(String apiBase, String additional, String json){
+    static ResponseEntity<String> putTo(String apiBase, String additional, JsonNode json){
         return postTo(apiBase, additional, json);
     }
 }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -30,8 +30,7 @@ public class SubsetsController {
 
     public SubsetsController(){
         if (prod){
-            String lds = System.getenv().getOrDefault("API_LDS", LDS_PROD);
-            LDS_SUBSET_API = lds;
+            LDS_SUBSET_API = System.getenv().getOrDefault("API_LDS", LDS_PROD);
         } else {
             LDS_SUBSET_API = LDS_LOCAL;
         }

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -1,0 +1,16 @@
+package no.ssb.subsetsservice;
+
+public class Utils {
+
+    public static boolean isYearMonthDay(String date){
+        return date.matches("([12]\\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01]))");
+    }
+
+    public static boolean isVersion(String version){
+        return version.matches("(\\d\\.\\d\\.\\d)");
+    }
+
+    public static boolean isClean(String str){
+        return str.matches("^[a-zA-Z0-9-_]+$");
+    }
+}

--- a/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
@@ -1,5 +1,8 @@
 package no.ssb.subsetsservice;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,9 +43,11 @@ class SubsetsServiceApplicationTests {
 				sb.append(myReader.nextLine());
 			}
 			myReader.close();
-			String subsetJSON = sb.toString();
-			System.out.println(subsetJSON);
-			ResponseEntity<String> response = SubsetsController.putTo(ldsURL, "/1", subsetJSON);
+			String subsetJSONString = sb.toString();
+			ObjectMapper mapper = new ObjectMapper();
+			JsonNode jsonNode = mapper.readTree(subsetJSONString);
+			System.out.println(subsetJSONString);
+			ResponseEntity<String> response = SubsetsController.putTo(ldsURL, "/1", jsonNode);
 
 			System.out.println("RESPONSE HEADERS:");
 			System.out.println(response.getHeaders());
@@ -53,11 +58,13 @@ class SubsetsServiceApplicationTests {
 		} catch (FileNotFoundException e) {
 			System.out.println("An error occurred.");
 			e.printStackTrace();
+		} catch (JsonProcessingException e) {
+			e.printStackTrace();
 		}
 	}
 
 	@Test
-	void getFromLDSlocal() {
+	void getFromLDSLocal() {
 		System.out.println("TESTING GET SUBSET BY ID 1 FROM LDS LOCAL INSTANCE");
 		ResponseEntity<String> response = SubsetsController.getFrom(ldsURL, "/1");
 
@@ -71,7 +78,7 @@ class SubsetsServiceApplicationTests {
 	}
 
 	@Test
-	void getAllFromLDSlocal() {
+	void getAllFromLDSLocal() {
 		System.out.println("TESTING GET ALL SUBSETS FROM LDS LOCAL INSTANCE");
 		ResponseEntity<String> response = SubsetsController.getFrom(ldsURL, "");
 		System.out.println("GET "+ldsURL);


### PR DESCRIPTION
NOTE: This was included in the PR with the port change before, but I separated it out into a different branch to be treated separately.

- Validates input parameters (subset IDs, dates, and versions) using a simple RegEx solution. If the parameters do not fit the RegEx, a 400 BAD REQUEST code is returned.

- Accept PUT/POST request bodies as JsonNodes. This adds built in safety/protection against injections, as far as I understand. Correct me if I'm wrong.

I've understand that `Filters` and the Filter Chain is used in Spring Security to sanitize and protect against XSS attacks and (SQL) injections, but I don't see that this is relevant here. If only valid JSON is accepted by PUT and POST requests, then no code can be injected, and no code will be run when the JSON is displayed or read anywhere.

I understand that the `@Valid` annotation and field annotations in a custom Class is used to validate JSON data that is supposed to be on the form of that class (classic Spring Boot style where data is transformed to and from JSON into instances of a specific Java class), but this is not the case here. 

_Maybe we should discuss how/if we will validate POSTed/PUT subsets JSON in the future?_