### PR TITLE
versions/{version} only returns perfect match

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -72,6 +72,8 @@ public class SubsetsController {
     /**
      * Get a subset corresponding to a given version string.
      * If {version} is "1.0.1", then that version of the subset will be returned
+     * If {version} is "1.0", then the latest patch of 1.0 will be returned.
+     * If {version} is "1", then the latest patch of 1 will be returned.
      * @param id
      * @param version
      * @return

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -89,7 +89,7 @@ public class SubsetsController {
                         for (int i = 0; i < responseBodyArrayNode.size(); i++) {
                             JsonNode arrayEntry = responseBodyArrayNode.get(i).get("document");
                             String subsetVersion = arrayEntry.get("version").asText();
-                            if (subsetVersion.equals(version)){
+                            if (subsetVersion.startsWith(version)){
                                 return new ResponseEntity<>(arrayEntry, HttpStatus.OK);
                             }
                         }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -70,9 +70,8 @@ public class SubsetsController {
     }
 
     /**
-     * Get a list of versions of a subset that starts with {versions}.
-     * So if {versions} is "1.0", then 1.0.0, 1.0.1, 1.0.2 etc will be returned.
-     * If {versions} is "1.0.1", then a list with a single item (1.0.1) will be returned
+     * Get a subset corresponding to a given version string.
+     * If {version} is "1.0.1", then that version of the subset will be returned
      * @param id
      * @param version
      * @return
@@ -87,15 +86,13 @@ public class SubsetsController {
                 if (responseBodyJSON != null){
                     if (responseBodyJSON.isArray()) {
                         ArrayNode responseBodyArrayNode = (ArrayNode) responseBodyJSON;
-                        ArrayNode returnVersionsArrayNode = mapper.createArrayNode();
                         for (int i = 0; i < responseBodyArrayNode.size(); i++) {
                             JsonNode arrayEntry = responseBodyArrayNode.get(i).get("document");
                             String subsetVersion = arrayEntry.get("version").asText();
-                            if (subsetVersion.startsWith(version)){
-                                returnVersionsArrayNode.add(arrayEntry);
+                            if (subsetVersion.equals(version)){
+                                return new ResponseEntity<>(arrayEntry, HttpStatus.OK);
                             }
                         }
-                        return new ResponseEntity<>(returnVersionsArrayNode, HttpStatus.OK);
                     }
                 }
                 return new ResponseEntity<>(HttpStatus.NOT_FOUND);


### PR DESCRIPTION
@alina-lapina said that I should remove the functionality where calling "versions/1" would return all patches of version 1.

Now you have to use the exact name of a patch: "versions/1.0.0" to get any answer at all.

Before an array of matches would be returned. Now, only a single subset is returned, without being in an array.

closes #12 