### PR TITLE
add cross origin anotation, which allows all cors by default

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+@CrossOrigin
 @RestController
 public class SubsetsController {
 


### PR DESCRIPTION
solves @alina-lapina s problem, I guess!

Opens up for requests from any origin on the whole API.

A whitelist can be defined at a later point when put into production.