### PR TITLE
version improvements

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -298,7 +298,9 @@ public class SubsetsController {
                         String entryValidFrom = version.get("validFrom").textValue();
                         String entryValidUntil = version.get("validUntil").textValue();
                         if (entryValidFrom.compareTo(date) <= 0 && entryValidUntil.compareTo(date) >= 0 ){
-                            return new ResponseEntity<>(version.get("codes"), HttpStatus.OK);
+                                ArrayNode codeArray = mapper.createArrayNode();
+                                version.get("codes").forEach(e -> codeArray.add(e.get("document")));
+                                return new ResponseEntity<>(codeArray, HttpStatus.OK);
                         }
                     }
                     return new ResponseEntity<>(HttpStatus.NOT_FOUND);

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -178,6 +178,7 @@ public class SubsetsController {
      */
     @GetMapping("/v1/subsets/{id}/codes")
     public ResponseEntity<JsonNode> getSubsetCodes(@PathVariable("id") String id, @RequestParam(required = false) String from, @RequestParam(required = false) String to) {
+        LOG.debug("GET subsets/id/codes");
         if (Utils.isClean(id)){
             if (from == null && to == null){
                 LOG.debug("getting all codes of the latest/current version of subset "+id);
@@ -286,6 +287,7 @@ public class SubsetsController {
      */
     @GetMapping("/v1/subsets/{id}/codesAt")
     public ResponseEntity<JsonNode> getSubsetCodesAt(@PathVariable("id") String id, @RequestParam String date) {
+        LOG.debug("GET subsets/id/codesAt");
         if (date != null && Utils.isClean(id) && (Utils.isYearMonthDay(date))){
             ResponseEntity<JsonNode> ldsRE = getFrom(LDS_SUBSET_API, "/"+id+"?timeline");
             ObjectMapper mapper = new ObjectMapper();
@@ -298,8 +300,9 @@ public class SubsetsController {
                         String entryValidFrom = version.get("validFrom").textValue();
                         String entryValidUntil = version.get("validUntil").textValue();
                         if (entryValidFrom.compareTo(date) <= 0 && entryValidUntil.compareTo(date) >= 0 ){
+                            LOG.debug("Found valid codes at "+date+". "+version.get("codes").size());
                                 ArrayNode codeArray = mapper.createArrayNode();
-                                version.get("codes").forEach(e -> codeArray.add(e.get("document")));
+                                version.get("codes").forEach(e -> codeArray.add(e.get("urn")));
                                 return new ResponseEntity<>(codeArray, HttpStatus.OK);
                         }
                     }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -32,6 +32,10 @@ public class SubsetsController {
     private static final boolean prod = true;
 
     public SubsetsController(){
+        updateLDSURL();
+    }
+
+    private void updateLDSURL(){
         if (prod){
             LDS_SUBSET_API = System.getenv().getOrDefault("API_LDS", LDS_PROD);
         } else {

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -64,6 +64,7 @@ public class SubsetsController {
     public ResponseEntity<String> getSubset(@PathVariable("id") String id) {
         if (Utils.isClean(id))
             return getFrom(LDS_SUBSET_API, "/"+id);
+        return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
 
     @PutMapping(value = "/v1/subsets/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -26,7 +26,7 @@ public class SubsetsController {
 
     private static String KLASS_CLASSIFICATIONS_API = "https://data.ssb.no/api/klass/v1/classifications";
 
-    private static final boolean prod = false;
+    private static final boolean prod = true;
 
     public SubsetsController(){
         if (prod){
@@ -57,7 +57,7 @@ public class SubsetsController {
             if (ldsResponse.getStatusCodeValue() == 404)
                 return postTo(LDS_SUBSET_API, "/" + id, subsetsJson);
         }
-        return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>("Can not POST subset with id that is already in use. Use PUT to update existing subsets", HttpStatus.BAD_REQUEST);
     }
 
     @GetMapping("/v1/subsets/{id}")

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -38,7 +38,7 @@ public class SubsetsController {
     }
 
     @GetMapping("/v1/subsets")
-    public ResponseEntity<String> getSubsets() {
+    public ResponseEntity<JsonNode> getSubsets() {
         return getFrom(LDS_SUBSET_API, "");
     }
 
@@ -49,82 +49,73 @@ public class SubsetsController {
      * @return
      */
     @PostMapping("/v1/subsets")
-    public ResponseEntity<String> postSubset(@RequestBody JsonNode subsetsJson) {
+    public ResponseEntity<JsonNode> postSubset(@RequestBody JsonNode subsetsJson) {
+        ObjectMapper mapper = new ObjectMapper();
         if (subsetsJson != null) {
             JsonNode idJN = subsetsJson.get("id");
             String id = idJN.textValue();
-            ResponseEntity<String> ldsResponse = getFrom(LDS_SUBSET_API, "/"+id);
+            ResponseEntity<JsonNode> ldsResponse = getFrom(LDS_SUBSET_API, "/"+id);
             if (ldsResponse.getStatusCodeValue() == 404)
                 return postTo(LDS_SUBSET_API, "/" + id, subsetsJson);
         }
-        return new ResponseEntity<>("Can not POST subset with id that is already in use. Use PUT to update existing subsets", HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(mapper.createObjectNode().put("error","Can not POST subset with id that is already in use. Use PUT to update existing subsets"), HttpStatus.BAD_REQUEST);
     }
 
     @GetMapping("/v1/subsets/{id}")
-    public ResponseEntity<String> getSubset(@PathVariable("id") String id) {
+    public ResponseEntity<JsonNode> getSubset(@PathVariable("id") String id) {
         if (Utils.isClean(id))
             return getFrom(LDS_SUBSET_API, "/"+id);
         return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
 
     @PutMapping(value = "/v1/subsets/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<String> putSubset(@PathVariable("id") String id, @RequestBody JsonNode subsetJson) {
+    public ResponseEntity<JsonNode> putSubset(@PathVariable("id") String id, @RequestBody JsonNode subsetJson) {
 
+        ObjectMapper mapper = new ObjectMapper();
         if (Utils.isClean(id)) {
-            ObjectMapper mapper = new ObjectMapper();
-            ResponseEntity<String> responseEntity = getFrom(LDS_SUBSET_API, "/"+id);
+            ResponseEntity<JsonNode> responseEntity = getFrom(LDS_SUBSET_API, "/"+id);
 
-            try {
-                if (responseEntity.getStatusCodeValue() != 404){
-                    JsonNode responseBodyJSON = mapper.readTree(responseEntity.getBody());
-                    String currentAdminStatus = responseBodyJSON.get("administrativeStatus").textValue();
-                    String currentVersion = responseBodyJSON.get("version").textValue();
-                    String nextVersion = subsetJson.get("version").textValue();
-                    if (currentVersion.compareTo(nextVersion) < 0 || !currentAdminStatus.equals("OPEN")){ // Do not overwrite a published patch.
-                        return putTo(LDS_SUBSET_API, "/" + id, subsetJson);
-                    }
-                    return new ResponseEntity<>("trying to overwrite an already published patch of a subset", HttpStatus.BAD_REQUEST);
-                } else {
+            if (responseEntity.getStatusCodeValue() != 404){
+                JsonNode responseBodyJSON = responseEntity.getBody();
+                String currentAdminStatus = responseBodyJSON.get("administrativeStatus").textValue();
+                String currentVersion = responseBodyJSON.get("version").textValue();
+                String nextVersion = subsetJson.get("version").textValue();
+                if (currentVersion.compareTo(nextVersion) < 0 || !currentAdminStatus.equals("OPEN")){ // Do not overwrite a published patch.
                     return putTo(LDS_SUBSET_API, "/" + id, subsetJson);
                 }
-            } catch (JsonProcessingException e) {
-                e.printStackTrace();
+                return new ResponseEntity<>(mapper.createObjectNode().put("error","trying to overwrite an already published patch of a subset"), HttpStatus.BAD_REQUEST);
+            } else {
+                return putTo(LDS_SUBSET_API, "/" + id, subsetJson);
             }
         }
-        return new ResponseEntity<>("id contains illegal characters", HttpStatus.BAD_REQUEST);
+        return new ResponseEntity<>(mapper.createObjectNode().put("error","id contains illegal characters"), HttpStatus.BAD_REQUEST);
     }
 
     @GetMapping("/v1/subsets/{id}/versions")
     public ResponseEntity<JsonNode> getVersions(@PathVariable("id") String id) {
         ObjectMapper mapper = new ObjectMapper();
         if (Utils.isClean(id)){
-            ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/"+id+"?timeline");
+            ResponseEntity<JsonNode> ldsRE = getFrom(LDS_SUBSET_API, "/"+id+"?timeline");
             ArrayNode arrayNode = mapper.createArrayNode();
-            try {
-                JsonNode responseBodyJSON = mapper.readTree(ldsRE.getBody());
-                if (responseBodyJSON != null){
-                    if (responseBodyJSON.isArray()) {
-                        ArrayNode responseBodyArrayNode = (ArrayNode) responseBodyJSON;
-                        Map<String, Boolean> versionMap = new HashMap<>(responseBodyArrayNode.size() * 2, 0.51f);
-                        for (int i = 0; i < responseBodyArrayNode.size(); i++) {
-                            JsonNode arrayEntry = responseBodyArrayNode.get(i).get("document");
-                            String subsetVersion = arrayEntry.get("version").textValue();
-                            if (!versionMap.containsKey(subsetVersion)){ // Only include the latest update of any patch
-                                arrayNode.add(arrayEntry);
-                                versionMap.put(subsetVersion, true);
-                            }
+            JsonNode responseBodyJSON = ldsRE.getBody();
+            if (responseBodyJSON != null){
+                if (responseBodyJSON.isArray()) {
+                    ArrayNode responseBodyArrayNode = (ArrayNode) responseBodyJSON;
+                    Map<String, Boolean> versionMap = new HashMap<>(responseBodyArrayNode.size() * 2, 0.51f);
+                    for (int i = 0; i < responseBodyArrayNode.size(); i++) {
+                        JsonNode arrayEntry = responseBodyArrayNode.get(i).get("document");
+                        String subsetVersion = arrayEntry.get("version").textValue();
+                        if (!versionMap.containsKey(subsetVersion)){ // Only include the latest update of any patch
+                            arrayNode.add(arrayEntry);
+                            versionMap.put(subsetVersion, true);
                         }
-                        return new ResponseEntity<>(arrayNode, HttpStatus.OK);
-                    } else {
-                        return new ResponseEntity<>(mapper.createObjectNode().put("error", "LDS response body was not JSON array"), HttpStatus.INTERNAL_SERVER_ERROR);
                     }
+                    return new ResponseEntity<>(arrayNode, HttpStatus.OK);
                 } else {
-                    return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+                    return new ResponseEntity<>(mapper.createObjectNode().put("error", "LDS response body was not JSON array"), HttpStatus.INTERNAL_SERVER_ERROR);
                 }
-            } catch (JsonProcessingException e) {
-                e.printStackTrace();
-                LOG.error(e.getMessage());
-                return new ResponseEntity<>(mapper.createObjectNode().put("error", "JsonProcessingException on response body from LDS timeline api"), HttpStatus.INTERNAL_SERVER_ERROR);
+            } else {
+                return new ResponseEntity<>(HttpStatus.NOT_FOUND);
             }
         } else {
             return new ResponseEntity<>(mapper.createObjectNode().put("error", "id contains illegal characters"), HttpStatus.BAD_REQUEST);
@@ -145,25 +136,21 @@ public class SubsetsController {
         ObjectMapper mapper = new ObjectMapper();
         if (Utils.isClean(id) && Utils.isVersion(version)){
             if (Utils.isVersion(version)){
-                ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/"+id+"?timeline");
-                try {
-                    JsonNode responseBodyJSON = mapper.readTree(ldsRE.getBody());
-                    if (responseBodyJSON != null){
-                        if (responseBodyJSON.isArray()) {
-                            ArrayNode responseBodyArrayNode = (ArrayNode) responseBodyJSON;
-                            for (int i = 0; i < responseBodyArrayNode.size(); i++) {
-                                JsonNode arrayEntry = responseBodyArrayNode.get(i).get("document");
-                                String subsetVersion = arrayEntry.get("version").textValue();
-                                if (subsetVersion.startsWith(version)){
-                                    return new ResponseEntity<>(arrayEntry, HttpStatus.OK);
-                                }
+                ResponseEntity<JsonNode> ldsRE = getFrom(LDS_SUBSET_API, "/"+id+"?timeline");
+                JsonNode responseBodyJSON = ldsRE.getBody();
+                if (responseBodyJSON != null){
+                    if (responseBodyJSON.isArray()) {
+                        ArrayNode responseBodyArrayNode = (ArrayNode) responseBodyJSON;
+                        for (int i = 0; i < responseBodyArrayNode.size(); i++) {
+                            JsonNode arrayEntry = responseBodyArrayNode.get(i).get("document");
+                            String subsetVersion = arrayEntry.get("version").textValue();
+                            if (subsetVersion.startsWith(version)){
+                                return new ResponseEntity<>(arrayEntry, HttpStatus.OK);
                             }
                         }
                     }
-                    return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-                } catch (JsonProcessingException e) {
-                    e.printStackTrace();
                 }
+                return new ResponseEntity<>(HttpStatus.NOT_FOUND);
             }
             return new ResponseEntity<>(mapper.createObjectNode().put("error", "malformed version"), HttpStatus.BAD_REQUEST);
         }
@@ -185,86 +172,77 @@ public class SubsetsController {
         if (Utils.isClean(id)){
             if (from == null || to == null){
                 LOG.debug("getting all codes of the latest/current version of subset "+id);
-                ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/"+id);
+                ResponseEntity<JsonNode> ldsRE = getFrom(LDS_SUBSET_API, "/"+id);
                 ObjectMapper mapper = new ObjectMapper();
-                try {
-                    JsonNode responseBodyJSON = mapper.readTree(ldsRE.getBody());
-                    if (responseBodyJSON != null){
-                        ArrayNode codes = (ArrayNode) responseBodyJSON.get("codes");
-                        ArrayNode urnArray = mapper.createArrayNode();
-                        for (int i = 0; i < codes.size(); i++) {
-                            urnArray.add(codes.get(i).get("urn").textValue());
-                        }
-                        return new ResponseEntity<>(urnArray, HttpStatus.OK);
+                JsonNode responseBodyJSON = ldsRE.getBody();
+                if (responseBodyJSON != null){
+                    ArrayNode codes = (ArrayNode) responseBodyJSON.get("codes");
+                    ArrayNode urnArray = mapper.createArrayNode();
+                    for (int i = 0; i < codes.size(); i++) {
+                        urnArray.add(codes.get(i).get("urn").textValue());
                     }
-                    return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-                } catch (JsonProcessingException e) {
-                    e.printStackTrace();
+                    return new ResponseEntity<>(urnArray, HttpStatus.OK);
                 }
-                return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+                return new ResponseEntity<>(HttpStatus.NOT_FOUND);
             }
 
             if (Utils.isYearMonthDay(from) && Utils.isYearMonthDay(to)) {
                 // If a date interval is specified using 'from' and 'to' query parameters
-                ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/" + id + "?timeline");
+                ResponseEntity<JsonNode> ldsRE = getFrom(LDS_SUBSET_API, "/" + id + "?timeline");
                 LOG.debug(String.format("Getting valid codes of subset %s from date %s to date %s", id, from, to));
                 ObjectMapper mapper = new ObjectMapper();
                 Map<String, Integer> codeMap = new HashMap<>();
                 int nrOfVersions;
-                try {
-                    JsonNode responseBodyJSON = mapper.readTree(ldsRE.getBody());
-                    if (responseBodyJSON != null) {
-                        if (responseBodyJSON.isArray()) {
-                            ArrayNode versionsArrayNode = (ArrayNode) responseBodyJSON;
-                            nrOfVersions = versionsArrayNode.size();
-                            LOG.debug("Nr of versions: " + nrOfVersions);
-                            JsonNode firstVersion = versionsArrayNode.get(versionsArrayNode.size() - 1).get("document");
-                            JsonNode lastVersion = versionsArrayNode.get(0).get("document");
-                            ArrayNode intersectionValidCodesInIntervalArrayNode = mapper.createArrayNode();
-                            // Check if first version includes fromDate, and last version includes toDate. If not, then return an empty list.
-                            String firstVersionValidFromString = firstVersion.get("validFrom").textValue().split("T")[0];
-                            String lastVersionValidUntilString = lastVersion.get("validUntil").textValue().split("T")[0];
-                            LOG.debug("First version valid from: " + firstVersionValidFromString);
-                            LOG.debug("Last version valid until: " + lastVersionValidUntilString);
-                            boolean isFirstValidAtOrBeforeFromDate = firstVersionValidFromString.compareTo(from) <= 0;
-                            LOG.debug("isFirstValidAtOrBeforeFromDate? " + isFirstValidAtOrBeforeFromDate);
-                            boolean isLastValidAtOrAfterToDate = lastVersionValidUntilString.compareTo(to) >= 0;
-                            LOG.debug("isLastValidAtOrAfterToDate? " + isLastValidAtOrAfterToDate);
-                            if (isFirstValidAtOrBeforeFromDate && isLastValidAtOrAfterToDate) {
-                                for (int i = 0; i < versionsArrayNode.size(); i++) {
-                                    // if this version has any overlap with the valid interval . . .
-                                    JsonNode arrayEntry = versionsArrayNode.get(i);
-                                    JsonNode subset = arrayEntry.get("document");
-                                    String validFromDateString = subset.get("validFrom").textValue().split("T")[0];
-                                    String validUntilDateString = subset.get("validUntil").textValue().split("T")[0];
-                                    if (validUntilDateString.compareTo(from) > 0 || validFromDateString.compareTo(to) < 0) {
-                                        LOG.debug("Version " + subset.get("version") + " is valid in the interval, so codes will be added to map");
-                                        // . . . using each code in this version as key, increment corresponding integer value in map
-                                        JsonNode codes = arrayEntry.get("document").get("codes");
-                                        ArrayNode codesArrayNode = (ArrayNode) codes;
-                                        LOG.debug("There are " + codesArrayNode.size() + " codes in this version");
-                                        for (int i1 = 0; i1 < codesArrayNode.size(); i1++) {
-                                            String codeURN = codesArrayNode.get(i1).get("urn").textValue();
-                                            codeMap.merge(codeURN, 1, Integer::sum);
-                                        }
+                JsonNode responseBodyJSON = ldsRE.getBody();
+                if (responseBodyJSON != null) {
+                    if (responseBodyJSON.isArray()) {
+                        ArrayNode versionsArrayNode = (ArrayNode) responseBodyJSON;
+                        nrOfVersions = versionsArrayNode.size();
+                        LOG.debug("Nr of versions: " + nrOfVersions);
+                        JsonNode firstVersion = versionsArrayNode.get(versionsArrayNode.size() - 1).get("document");
+                        JsonNode lastVersion = versionsArrayNode.get(0).get("document");
+                        ArrayNode intersectionValidCodesInIntervalArrayNode = mapper.createArrayNode();
+                        // Check if first version includes fromDate, and last version includes toDate. If not, then return an empty list.
+                        String firstVersionValidFromString = firstVersion.get("validFrom").textValue().split("T")[0];
+                        String lastVersionValidUntilString = lastVersion.get("validUntil").textValue().split("T")[0];
+                        LOG.debug("First version valid from: " + firstVersionValidFromString);
+                        LOG.debug("Last version valid until: " + lastVersionValidUntilString);
+                        boolean isFirstValidAtOrBeforeFromDate = firstVersionValidFromString.compareTo(from) <= 0;
+                        LOG.debug("isFirstValidAtOrBeforeFromDate? " + isFirstValidAtOrBeforeFromDate);
+                        boolean isLastValidAtOrAfterToDate = lastVersionValidUntilString.compareTo(to) >= 0;
+                        LOG.debug("isLastValidAtOrAfterToDate? " + isLastValidAtOrAfterToDate);
+                        if (isFirstValidAtOrBeforeFromDate && isLastValidAtOrAfterToDate) {
+                            for (int i = 0; i < versionsArrayNode.size(); i++) {
+                                // if this version has any overlap with the valid interval . . .
+                                JsonNode arrayEntry = versionsArrayNode.get(i);
+                                JsonNode subset = arrayEntry.get("document");
+                                String validFromDateString = subset.get("validFrom").textValue().split("T")[0];
+                                String validUntilDateString = subset.get("validUntil").textValue().split("T")[0];
+                                if (validUntilDateString.compareTo(from) > 0 || validFromDateString.compareTo(to) < 0) {
+                                    LOG.debug("Version " + subset.get("version") + " is valid in the interval, so codes will be added to map");
+                                    // . . . using each code in this version as key, increment corresponding integer value in map
+                                    JsonNode codes = arrayEntry.get("document").get("codes");
+                                    ArrayNode codesArrayNode = (ArrayNode) codes;
+                                    LOG.debug("There are " + codesArrayNode.size() + " codes in this version");
+                                    for (int i1 = 0; i1 < codesArrayNode.size(); i1++) {
+                                        String codeURN = codesArrayNode.get(i1).get("urn").textValue();
+                                        codeMap.merge(codeURN, 1, Integer::sum);
                                     }
                                 }
-                                // Only return codes that were in every version in the interval, (=> they were always valid)
-                                for (String key : codeMap.keySet()) {
-                                    int value = codeMap.get(key);
-                                    LOG.trace("key:" + key + " value:" + value);
-                                    if (value == nrOfVersions)
-                                        intersectionValidCodesInIntervalArrayNode.add(key);
-                                }
                             }
-                            LOG.debug("nr of valid codes: " + intersectionValidCodesInIntervalArrayNode.size());
-                            return new ResponseEntity<>(intersectionValidCodesInIntervalArrayNode, HttpStatus.OK);
+                            // Only return codes that were in every version in the interval, (=> they were always valid)
+                            for (String key : codeMap.keySet()) {
+                                int value = codeMap.get(key);
+                                LOG.trace("key:" + key + " value:" + value);
+                                if (value == nrOfVersions)
+                                    intersectionValidCodesInIntervalArrayNode.add(key);
+                            }
                         }
+                        LOG.debug("nr of valid codes: " + intersectionValidCodesInIntervalArrayNode.size());
+                        return new ResponseEntity<>(intersectionValidCodesInIntervalArrayNode, HttpStatus.OK);
                     }
-                    return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-                } catch (JsonProcessingException e) {
-                    e.printStackTrace();
                 }
+                return new ResponseEntity<>(HttpStatus.NOT_FOUND);
             }
         }
         return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
@@ -280,70 +258,66 @@ public class SubsetsController {
     @GetMapping("/v1/subsets/{id}/codesAt")
     public ResponseEntity<JsonNode> getSubsetCodesAt(@PathVariable("id") String id, @RequestParam String date) {
         if (date != null && Utils.isClean(id) && (Utils.isYearMonthDay(date))){
-            ResponseEntity<String> ldsRE = getFrom(LDS_SUBSET_API, "/"+id+"?timeline");
+            ResponseEntity<JsonNode> ldsRE = getFrom(LDS_SUBSET_API, "/"+id+"?timeline");
             ObjectMapper mapper = new ObjectMapper();
-            try {
-                JsonNode responseBodyJSON = mapper.readTree(ldsRE.getBody());
-                if (responseBodyJSON != null){
-                    if (responseBodyJSON.isArray()) {
-                        ArrayNode arrayNode = (ArrayNode) responseBodyJSON;
-                        for (int i = 0; i < arrayNode.size(); i++) {
-                            JsonNode version = arrayNode.get(i).get("document");
-                            String entryValidFrom = version.get("validFrom").textValue();
-                            String entryValidUntil = version.get("validUntil").textValue();
-                            if (entryValidFrom.compareTo(date) <= 0 && entryValidUntil.compareTo(date) >= 0 ){
-                                return new ResponseEntity<>(version.get("codes"), HttpStatus.OK);
-                            }
+            JsonNode responseBodyJSON = ldsRE.getBody();
+            if (responseBodyJSON != null){
+                if (responseBodyJSON.isArray()) {
+                    ArrayNode arrayNode = (ArrayNode) responseBodyJSON;
+                    for (int i = 0; i < arrayNode.size(); i++) {
+                        JsonNode version = arrayNode.get(i).get("document");
+                        String entryValidFrom = version.get("validFrom").textValue();
+                        String entryValidUntil = version.get("validUntil").textValue();
+                        if (entryValidFrom.compareTo(date) <= 0 && entryValidUntil.compareTo(date) >= 0 ){
+                            return new ResponseEntity<>(version.get("codes"), HttpStatus.OK);
                         }
-                        return new ResponseEntity<>(HttpStatus.NOT_FOUND);
                     }
+                    return new ResponseEntity<>(HttpStatus.NOT_FOUND);
                 }
-            } catch (JsonProcessingException e) {
-                e.printStackTrace();
             }
         }
         return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
 
     @GetMapping("/v1/subsets?schema")
-    public ResponseEntity<String> getSchema(){
+    public ResponseEntity<JsonNode> getSchema(){
         return getFrom(LDS_SUBSET_API,"/?schema");
     }
 
     @GetMapping("/v1/classifications")
-    public ResponseEntity<String> getClassifications(){
+    public ResponseEntity<JsonNode> getClassifications(){
         return getFrom(KLASS_CLASSIFICATIONS_API, ".json");
     }
 
     @GetMapping("/v1/classifications/{id}")
-    public ResponseEntity<String> getClassification(@PathVariable("id") String id){
+    public ResponseEntity<JsonNode> getClassification(@PathVariable("id") String id){
         if (Utils.isClean(id))
             return getFrom(KLASS_CLASSIFICATIONS_API, "/"+id+".json");
         return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
     }
 
-    static ResponseEntity<String> getFrom(String apiBase, String additional)
+    static ResponseEntity<JsonNode> getFrom(String apiBase, String additional)
     {
         // TODO: I am not sure if this is the right way of handling 404's from another server.
         try {
-            ResponseEntity<String> response = new RestTemplate().getForEntity(apiBase + additional, String.class);
+            ResponseEntity<JsonNode> response = new RestTemplate().getForEntity(apiBase + additional, JsonNode.class);
             return response;
         } catch (HttpClientErrorException e){
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
     }
 
-    static ResponseEntity<String> postTo(String apiBase, String additional, JsonNode json){
+    static ResponseEntity<JsonNode> postTo(String apiBase, String additional, JsonNode json){
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
         HttpEntity<JsonNode> request = new HttpEntity<>(json, headers);
-        ResponseEntity<String> response = new RestTemplate().postForEntity(apiBase+additional, request, String.class);
+        ResponseEntity<JsonNode> response = new RestTemplate().postForEntity(apiBase+additional, request, JsonNode.class);
         LOG.debug("POST to "+apiBase+additional+" - Status: "+response.getStatusCodeValue()+" "+response.getStatusCode().name());
         return response;
     }
 
-    static ResponseEntity<String> putTo(String apiBase, String additional, JsonNode json){
+    static ResponseEntity<JsonNode> putTo(String apiBase, String additional, JsonNode json){
         return postTo(apiBase, additional, json);
     }
 }

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -7,7 +7,7 @@ public class Utils {
     }
 
     public static boolean isVersion(String version){
-        return version.matches("(\\d\\.\\d\\.\\d)");
+        return version.matches("(\\d(\\.\\d)?(\\.\\d)?)");
     }
 
     public static boolean isClean(String str){

--- a/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
@@ -47,7 +47,7 @@ class SubsetsServiceApplicationTests {
 			ObjectMapper mapper = new ObjectMapper();
 			JsonNode jsonNode = mapper.readTree(subsetJSONString);
 			System.out.println(subsetJSONString);
-			ResponseEntity<String> response = SubsetsController.putTo(ldsURL, "/1", jsonNode);
+			ResponseEntity<JsonNode> response = SubsetsController.putTo(ldsURL, "/1", jsonNode);
 
 			System.out.println("RESPONSE HEADERS:");
 			System.out.println(response.getHeaders());
@@ -66,7 +66,7 @@ class SubsetsServiceApplicationTests {
 	@Test
 	void getFromLDSLocal() {
 		System.out.println("TESTING GET SUBSET BY ID 1 FROM LDS LOCAL INSTANCE");
-		ResponseEntity<String> response = SubsetsController.getFrom(ldsURL, "/1");
+		ResponseEntity<JsonNode> response = SubsetsController.getFrom(ldsURL, "/1");
 
 		System.out.println("GET "+ldsURL+"/1");
 		System.out.println("RESPONSE HEADERS:");
@@ -80,7 +80,7 @@ class SubsetsServiceApplicationTests {
 	@Test
 	void getAllFromLDSLocal() {
 		System.out.println("TESTING GET ALL SUBSETS FROM LDS LOCAL INSTANCE");
-		ResponseEntity<String> response = SubsetsController.getFrom(ldsURL, "");
+		ResponseEntity<JsonNode> response = SubsetsController.getFrom(ldsURL, "");
 		System.out.println("GET "+ldsURL);
 		System.out.println("RESPONSE HEADERS:");
 		System.out.println(response.getHeaders());


### PR DESCRIPTION
Things that this PR does:
- You can't POST a subset with an ID that already exists in LDS
- If LDS contains several version of a patch (for example, there are several different version of "1.0.0" in LDS timeline), only include the latest (timestamp wise) version of that patch in the array returned by `id/versions`.
- You can not update a published subset patch with PUT (for example, you can __not__ PUT a new "1.0.0" if 1.0.0 has administrationStatus OPEN, but you _can_ if it has any other status)
- We provide better feedback/messages on bad requests
- We provide better feedback on internal server errors resulting from LDS not working
- My regex checking for legal version format now matches versions on the form "1" and "1.0", not only "1.0.0"
- We receive request bodies as JsonNodes directly, instead of parsing them using an object mapper.
- codesAt now returns array of code urns