### PR TITLE
Update names, cleaner error handling, clean versions, bugfixes/correctness

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/ErrorHandler.java
+++ b/src/main/java/no/ssb/subsetsservice/ErrorHandler.java
@@ -1,0 +1,29 @@
+package no.ssb.subsetsservice;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class ErrorHandler {
+
+    public static final String ILLEGAL_ID = "id contains illegal characters";
+    public static final String MALFORMED_VERSION = "malformed version";
+
+    public static ResponseEntity<JsonNode> newError(String message, HttpStatus status){
+        ObjectNode body = new ObjectMapper().createObjectNode();
+        body.put("error", message);
+        body.put("timestamp", Utils.getNowISO());
+        body.put("httpStatus", status.value());
+        return new ResponseEntity<>(body, status);
+    }
+
+    public static ResponseEntity<JsonNode> illegalID(){
+        return newError(ErrorHandler.ILLEGAL_ID, HttpStatus.BAD_REQUEST);
+    }
+
+    public static ResponseEntity<JsonNode> malformedVersion(){
+        return newError(ErrorHandler.MALFORMED_VERSION, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/no/ssb/subsetsservice/ErrorHandler.java
+++ b/src/main/java/no/ssb/subsetsservice/ErrorHandler.java
@@ -5,25 +5,28 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.slf4j.Logger;
 
 public class ErrorHandler {
 
     public static final String ILLEGAL_ID = "id contains illegal characters";
     public static final String MALFORMED_VERSION = "malformed version";
 
-    public static ResponseEntity<JsonNode> newError(String message, HttpStatus status){
+    public static ResponseEntity<JsonNode> newError(String message, HttpStatus status, Logger logger){
         ObjectNode body = new ObjectMapper().createObjectNode();
-        body.put("error", message);
+        body.put("status", status.value());
+        body.put("error", status.toString());
+        body.put("message", message);
         body.put("timestamp", Utils.getNowISO());
-        body.put("httpStatus", status.value());
+        logger.error(body.toPrettyString());
         return new ResponseEntity<>(body, status);
     }
 
-    public static ResponseEntity<JsonNode> illegalID(){
-        return newError(ErrorHandler.ILLEGAL_ID, HttpStatus.BAD_REQUEST);
+    public static ResponseEntity<JsonNode> illegalID(Logger logger){
+        return newError(ErrorHandler.ILLEGAL_ID, HttpStatus.BAD_REQUEST, logger);
     }
 
-    public static ResponseEntity<JsonNode> malformedVersion(){
-        return newError(ErrorHandler.MALFORMED_VERSION, HttpStatus.BAD_REQUEST);
+    public static ResponseEntity<JsonNode> malformedVersion(Logger logger){
+        return newError(ErrorHandler.MALFORMED_VERSION, HttpStatus.BAD_REQUEST, logger);
     }
 }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -332,19 +332,4 @@ public class SubsetsController {
         return consumer.getFrom("/?schema");
     }
 
-    @GetMapping("/v1/classifications")
-    public ResponseEntity<JsonNode> getClassifications(){
-        LDSConsumer consumer = new LDSConsumer(LDS_SUBSET_API);
-        return consumer.getFrom(".json");
-    }
-
-    @GetMapping("/v1/classifications/{id}")
-    public ResponseEntity<JsonNode> getClassification(@PathVariable("id") String id){
-        if (Utils.isClean(id)) {
-            LDSConsumer consumer = new LDSConsumer(LDS_SUBSET_API);
-            return consumer.getFrom("/" + id + ".json");
-        }
-        return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
-    }
-
 }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -37,13 +37,19 @@ public class SubsetsController {
         } else {
             LDS_SUBSET_API = LDS_LOCAL;
         }
+        LOG.info("Running with LDS url "+LDS_SUBSET_API);
         KLASS_CLASSIFICATIONS_API = System.getenv().getOrDefault("API_KLASS", KLASS_CLASSIFICATIONS_API);
     }
 
     @GetMapping("/v1/subsets")
     public ResponseEntity<JsonNode> getSubsets() {
         LDSConsumer consumer = new LDSConsumer(LDS_SUBSET_API);
-        return consumer.getFrom("");
+        ResponseEntity<JsonNode> ldsRE = consumer.getFrom("");
+        ArrayNode ldsAllSubsetsArrayNode = (ArrayNode) ldsRE.getBody();
+        for (int i = 0; i < ldsAllSubsetsArrayNode.size(); i++) {
+            ldsAllSubsetsArrayNode.set(i, getVersions(ldsAllSubsetsArrayNode.get(i).get("id").asText()).getBody().get(0));
+        }
+        return new ResponseEntity<>(ldsAllSubsetsArrayNode, HttpStatus.OK);
     }
 
     /**
@@ -54,7 +60,6 @@ public class SubsetsController {
      */
     @PostMapping("/v1/subsets")
     public ResponseEntity<JsonNode> postSubset(@RequestBody JsonNode subsetJson) {
-        ObjectMapper mapper = new ObjectMapper();
         if (subsetJson != null) {
             JsonNode idJN = subsetJson.get("id");
             String id = idJN.textValue();
@@ -65,18 +70,23 @@ public class SubsetsController {
             LDSConsumer consumer = new LDSConsumer(LDS_SUBSET_API);
             ResponseEntity<JsonNode> ldsResponse = consumer.getFrom("/"+id);
             if (ldsResponse.getStatusCodeValue() == 404)
-                return consumer.postTo("/" + id, subsetJson);
+                return consumer.postTo("/" + id, Utils.cleanSubsetVersion(subsetJson));
         }
-        return new ResponseEntity<>(mapper.createObjectNode().put("error","Can not POST subset with id that is already in use. Use PUT to update existing subsets"), HttpStatus.BAD_REQUEST);
+        return ErrorHandler.newError("Can not POST subset with id that is already in use. Use PUT to update existing subsets", HttpStatus.BAD_REQUEST, LOG);
     }
 
     @GetMapping("/v1/subsets/{id}")
     public ResponseEntity<JsonNode> getSubset(@PathVariable("id") String id) {
         if (Utils.isClean(id)){
-            LDSConsumer consumer = new LDSConsumer(LDS_SUBSET_API);
-            return consumer.getFrom("/"+id);
+            ResponseEntity<JsonNode> majorVersions = getVersions(id);
+            if (majorVersions.getBody().isArray()){
+                ArrayNode majorVersionsArray = (ArrayNode) majorVersions.getBody();
+                return new ResponseEntity<>(majorVersionsArray.get(0), HttpStatus.OK);
+            } else {
+                return ErrorHandler.newError("internal call to /versions did not return array", HttpStatus.INTERNAL_SERVER_ERROR, LOG);
+            }
         }
-        return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        return ErrorHandler.illegalID(LOG);
     }
 
     @PutMapping(value = "/v1/subsets/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
@@ -89,7 +99,7 @@ public class SubsetsController {
             LDSConsumer consumer = new LDSConsumer(LDS_SUBSET_API);
             return consumer.putTo("/" + id, editableSubset);
         } else {
-            return new ResponseEntity<>(mapper.createObjectNode().put("error", "id contains illegal characters"), HttpStatus.BAD_REQUEST);
+            return ErrorHandler.illegalID(LOG);
         }
     }
 
@@ -99,8 +109,8 @@ public class SubsetsController {
         if (Utils.isClean(id)){
             LDSConsumer consumer = new LDSConsumer(LDS_SUBSET_API);
             ResponseEntity<JsonNode> ldsRE = consumer.getFrom("/"+id+"?timeline");
-            ArrayNode majorVersionsArrayNode = mapper.createArrayNode();
             JsonNode responseBodyJSON = ldsRE.getBody();
+            ArrayNode majorVersionsArrayNode = mapper.createArrayNode();
             if (responseBodyJSON != null){
                 if (responseBodyJSON.isArray()) {
                     ArrayNode versionsArrayNode = (ArrayNode) responseBodyJSON;
@@ -109,21 +119,15 @@ public class SubsetsController {
                         ObjectNode subsetVersionDocument = versionNode.get("document").deepCopy();
                         JsonNode self = Utils.getSelfLinkObject(mapper, ServletUriComponentsBuilder.fromCurrentRequestUri(), subsetVersionDocument);
                         subsetVersionDocument.set("_links", self);
-                        String subsetVersion = subsetVersionDocument.get("version").textValue().split("\\.")[0];
-                        if (!versionMap.containsKey(subsetVersion)){ // Only include the latest update of any major version
+                        String subsetMajorVersion = subsetVersionDocument.get("version").textValue().split("\\.")[0];
+                        if (!versionMap.containsKey(subsetMajorVersion)){ // Only include the latest update of any major version
                             majorVersionsArrayNode.add(subsetVersionDocument);
-                            versionMap.put(subsetVersion, true);
+                            versionMap.put(subsetMajorVersion, true);
                         }
                     }
+                    Utils.sortByVersion(majorVersionsArrayNode);
                     JsonNode latestVersionNode = majorVersionsArrayNode.get(0);
-                    int latestVersion = 0;
-                    for (JsonNode versionNode : majorVersionsArrayNode) {
-                        int thisVersion = Integer.parseInt(versionNode.get("version").asText().split("\\.")[0]);
-                        if (thisVersion > latestVersion){
-                            latestVersionNode = versionNode;
-                            latestVersion = thisVersion;
-                        }
-                    }
+                    //JsonNode latestVersionNode = Utils.getLatestMajorVersion(majorVersionsArrayNode);
                     JsonNode name = latestVersionNode.get("name");
                     JsonNode shortName = latestVersionNode.get("shortName");
                     ArrayNode majorVersionsObjectNodeArray = mapper.createArrayNode();
@@ -131,17 +135,18 @@ public class SubsetsController {
                         ObjectNode objectNode = versionNode.deepCopy();
                         objectNode.set("name", name);
                         objectNode.set("shortName", shortName);
+                        objectNode.put("version", objectNode.get("version").asText().split("\\.")[0]);
                         majorVersionsObjectNodeArray.add(objectNode);
                     }
                     return new ResponseEntity<>(majorVersionsObjectNodeArray, HttpStatus.OK);
                 } else {
-                    return new ResponseEntity<>(mapper.createObjectNode().put("error", "LDS response body was not JSON array"), HttpStatus.INTERNAL_SERVER_ERROR);
+                    return ErrorHandler.newError("LDS response body was not JSON array", HttpStatus.INTERNAL_SERVER_ERROR, LOG);
                 }
             } else {
                 return new ResponseEntity<>(HttpStatus.NOT_FOUND);
             }
         } else {
-            return new ResponseEntity<>(mapper.createObjectNode().put("error", "id contains illegal characters"), HttpStatus.BAD_REQUEST);
+            return ErrorHandler.illegalID(LOG);
         }
     }
 
@@ -156,7 +161,6 @@ public class SubsetsController {
      */
     @GetMapping("/v1/subsets/{id}/versions/{version}")
     public ResponseEntity<JsonNode> getVersion(@PathVariable("id") String id, @PathVariable("version") String version) {
-        ObjectMapper mapper = new ObjectMapper();
         if (Utils.isClean(id) && Utils.isVersion(version)){
             if (Utils.isVersion(version)){
                 ResponseEntity<JsonNode> versionsRE = getVersions(id);
@@ -164,8 +168,7 @@ public class SubsetsController {
                 if (responseBodyJSON != null){
                     if (responseBodyJSON.isArray()) {
                         ArrayNode versionsArrayNode = (ArrayNode) responseBodyJSON;
-                        for (JsonNode jsonNode : versionsArrayNode) {
-                            JsonNode arrayEntry = jsonNode.get("document");
+                        for (JsonNode arrayEntry : versionsArrayNode) {
                             String subsetVersion = arrayEntry.get("version").textValue();
                             if (subsetVersion.startsWith(version)){
                                 return new ResponseEntity<>(arrayEntry, HttpStatus.OK);
@@ -175,9 +178,9 @@ public class SubsetsController {
                 }
                 return new ResponseEntity<>(HttpStatus.NOT_FOUND);
             }
-            return new ResponseEntity<>(mapper.createObjectNode().put("error", "malformed version"), HttpStatus.BAD_REQUEST);
+            return ErrorHandler.malformedVersion(LOG);
         }
-        return new ResponseEntity<>(mapper.createObjectNode().put("error", "id contains illegal characters"), HttpStatus.BAD_REQUEST);
+        return ErrorHandler.illegalID(LOG);
     }
 
     /**

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -67,11 +67,11 @@ public class Utils {
     }
 
     public static JsonNode getLatestMajorVersion(ArrayNode majorVersionsArrayNode){
-        JsonNode latestVersionNode = majorVersionsArrayNode.get(0);
+        JsonNode latestVersionNode = null;
         int latestVersion = 0;
         for (JsonNode versionNode : majorVersionsArrayNode) {
             int thisVersion = Integer.parseInt(versionNode.get("version").asText().split("\\.")[0]);
-            if (thisVersion > latestVersion){
+            if (latestVersionNode == null || thisVersion > latestVersion){
                 latestVersionNode = versionNode;
                 latestVersion = thisVersion;
             }

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -10,7 +10,9 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.TimeZone;
 
 public class Utils {
@@ -28,7 +30,7 @@ public class Utils {
     }
 
     public static JsonNode getSelfLinkObject(ObjectMapper mapper, ServletUriComponentsBuilder servletUriComponentsBuilder, JsonNode subset){
-        String subsetVersion = subset.get("version").textValue();
+        String subsetVersion = subset.get("version").textValue().split("\\.")[0];
         ObjectNode hrefNode = mapper.createObjectNode();
         hrefNode.put("href", servletUriComponentsBuilder.toUriString()+"/"+subsetVersion);
         ObjectNode self = mapper.createObjectNode();
@@ -38,7 +40,7 @@ public class Utils {
 
     public static String getNowISO(){
         TimeZone tz = TimeZone.getTimeZone("UTC");
-        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'"); // Quoted "Z" to indicate UTC, no timezone offset
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'"); // Quoted "Z" to indicate UTC, no timezone offset
         df.setTimeZone(tz);
         String nowAsISO = df.format(new Date());
         return nowAsISO;
@@ -75,6 +77,15 @@ public class Utils {
             }
         }
         return latestVersionNode;
+    }
+
+    public static void sortByVersion(ArrayNode subsetArrayNode){
+        List<JsonNode> subsetList = new ArrayList<>(subsetArrayNode.size());
+        subsetArrayNode.forEach(subsetList::add);
+        subsetList.sort((s1, s2) -> Integer.compare(Integer.parseInt(s2.get("version").asText().split("\\.")[0]), Integer.parseInt(s1.get("version").asText().split("\\.")[0])));
+        for (int i = 0; i < subsetList.size(); i++) {
+            subsetArrayNode.set(i, subsetList.get(i));
+        }
     }
 
 }


### PR DESCRIPTION
- Fixed some bugs that made the api return bad and wrong things.
- The name used in the latest major version will be used in all versions (Right now administrationStatus is not taken into account)
- We now have an ErrorHandler class that builds, logs and returns proper error messages.
- Only major version numbers like "3" will be shown to the user, even if the version is saved as "3.0.1" or something similar.
