### PR TITLE
version ordering, update name correctly, ensure apropriate 404 responses

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/ErrorHandler.java
+++ b/src/main/java/no/ssb/subsetsservice/ErrorHandler.java
@@ -22,13 +22,13 @@ public class ErrorHandler {
         return new ResponseEntity<>(body, status);
     }
 
-    public static ObjectNode newJsonError(String userMessage, Exception e, Logger logger){
+    public static void newJsonError(String userMessage, Exception e, Logger logger){
         ObjectNode json = new ObjectMapper().createObjectNode();
         json.put("user message", userMessage);
         json.put("exception message", e.getMessage());
         json.put("timestamp", Utils.getNowISO());
         json.put("e.toString", e.toString());
-        return json;
+        logger.error(json.toPrettyString());
     }
 
     public static ResponseEntity<JsonNode> illegalID(Logger logger){

--- a/src/main/java/no/ssb/subsetsservice/ErrorHandler.java
+++ b/src/main/java/no/ssb/subsetsservice/ErrorHandler.java
@@ -12,7 +12,7 @@ public class ErrorHandler {
     public static final String ILLEGAL_ID = "id contains illegal characters";
     public static final String MALFORMED_VERSION = "malformed version";
 
-    public static ResponseEntity<JsonNode> newError(String message, HttpStatus status, Logger logger){
+    public static ResponseEntity<JsonNode> newHttpError(String message, HttpStatus status, Logger logger){
         ObjectNode body = new ObjectMapper().createObjectNode();
         body.put("status", status.value());
         body.put("error", status.toString());
@@ -22,11 +22,20 @@ public class ErrorHandler {
         return new ResponseEntity<>(body, status);
     }
 
+    public static ObjectNode newJsonError(String userMessage, Exception e, Logger logger){
+        ObjectNode json = new ObjectMapper().createObjectNode();
+        json.put("user message", userMessage);
+        json.put("exception message", e.getMessage());
+        json.put("timestamp", Utils.getNowISO());
+        json.put("e.toString", e.toString());
+        return json;
+    }
+
     public static ResponseEntity<JsonNode> illegalID(Logger logger){
-        return newError(ErrorHandler.ILLEGAL_ID, HttpStatus.BAD_REQUEST, logger);
+        return newHttpError(ErrorHandler.ILLEGAL_ID, HttpStatus.BAD_REQUEST, logger);
     }
 
     public static ResponseEntity<JsonNode> malformedVersion(Logger logger){
-        return newError(ErrorHandler.MALFORMED_VERSION, HttpStatus.BAD_REQUEST, logger);
+        return newHttpError(ErrorHandler.MALFORMED_VERSION, HttpStatus.BAD_REQUEST, logger);
     }
 }

--- a/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.*;
 import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Collections;
@@ -22,10 +23,13 @@ public class LDSConsumer {
     {
         // TODO: I am not sure if this is the right way of handling 404's from another server.
         try {
-            ResponseEntity<JsonNode> response = new RestTemplate().getForEntity(LDS_URL + additional, JsonNode.class);
-            return response;
+            return new RestTemplate().getForEntity(LDS_URL + additional, JsonNode.class);
         } catch (HttpClientErrorException e){
+            ErrorHandler.newHttpError("could not retrieve "+LDS_URL+additional+".", e.getStatusCode(), LOG);
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (HttpServerErrorException e){
+            ErrorHandler.newJsonError("message", e, LOG);
+            return ErrorHandler.newHttpError("could not retrieve "+LDS_URL+additional+".", e.getStatusCode(), LOG);
         }
     }
 

--- a/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
@@ -25,10 +25,8 @@ public class LDSConsumer {
         try {
             return new RestTemplate().getForEntity(LDS_URL + additional, JsonNode.class);
         } catch (HttpClientErrorException e){
-            ErrorHandler.newHttpError("could not retrieve "+LDS_URL+additional+".", e.getStatusCode(), LOG);
-            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+            return ErrorHandler.newHttpError("could not retrieve "+LDS_URL+additional+".", e.getStatusCode(), LOG);
         } catch (HttpServerErrorException e){
-            ErrorHandler.newJsonError("message", e, LOG);
             return ErrorHandler.newHttpError("could not retrieve "+LDS_URL+additional+".", e.getStatusCode(), LOG);
         }
     }

--- a/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
@@ -21,12 +21,9 @@ public class LDSConsumer {
 
     ResponseEntity<JsonNode> getFrom(String additional)
     {
-        // TODO: I am not sure if this is the right way of handling 404's from another server.
         try {
             return new RestTemplate().getForEntity(LDS_URL + additional, JsonNode.class);
-        } catch (HttpClientErrorException e){
-            return ErrorHandler.newHttpError("could not retrieve "+LDS_URL+additional+".", e.getStatusCode(), LOG);
-        } catch (HttpServerErrorException e){
+        } catch (HttpClientErrorException | HttpServerErrorException e){
             return ErrorHandler.newHttpError("could not retrieve "+LDS_URL+additional+".", e.getStatusCode(), LOG);
         }
     }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -164,20 +164,21 @@ public class SubsetsController {
                     for (int i = keyArray.length - 1; i >= 0; i--) {
                         majorVersionsArrayNode.add(versionLastUpdatedMap.get(keyArray[i]));
                     }
-                    JsonNode latestPublishedVersionNode = Utils.getLatestMajorVersion(majorVersionsArrayNode, true);
-                    int latestPublishedVersion = Integer.parseInt(latestPublishedVersionNode.get("version").asText().split("\\.")[0]);
+                    JsonNode latestVersion = Utils.getLatestMajorVersion(majorVersionsArrayNode, false);
+                    // JsonNode latestPublishedVersionNode = Utils.getLatestMajorVersion(majorVersionsArrayNode, true);
+                    int latestMajorVersion = Integer.parseInt(latestVersion.get("version").asText().split("\\.")[0]);
 
                     ArrayNode majorVersionsObjectNodeArray = mapper.createArrayNode();
                     for (JsonNode versionNode : majorVersionsArrayNode) {
                         ObjectNode objectNode = versionNode.deepCopy();
                         int version = Integer.parseInt(objectNode.get("version").asText().split("\\.")[0]);
                         objectNode.put("version", version);
-                        if (version < latestPublishedVersion && objectNode.get("administrativeStatus").asText().equals("OPEN")){
-                            if (latestPublishedVersionNode.has("name")){
-                                objectNode.set("name", latestPublishedVersionNode.get("name"));
+                        if (version < latestMajorVersion && objectNode.get("administrativeStatus").asText().equals("OPEN")){
+                            if (latestVersion.has("name")){
+                                objectNode.set("name", latestVersion.get("name"));
                             }
-                            if (latestPublishedVersionNode.has("shortName")){
-                                objectNode.set("shortName", latestPublishedVersionNode.get("shortName"));
+                            if (latestVersion.has("shortName")){
+                                objectNode.set("shortName", latestVersion.get("shortName"));
                             }
                         }
                         majorVersionsObjectNodeArray.add(objectNode);

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -96,7 +96,6 @@ public class SubsetsController {
     @PutMapping(value = "/v1/subsets/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<JsonNode> putSubset(@PathVariable("id") String id, @RequestBody JsonNode subsetJson) {
 
-        ObjectMapper mapper = new ObjectMapper();
         if (Utils.isClean(id)) {
             ObjectNode editableSubset = subsetJson.deepCopy();
             editableSubset.put("lastUpdatedDate", Utils.getNowISO());

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -27,7 +27,7 @@ public class SubsetsController {
 
     private static String KLASS_CLASSIFICATIONS_API = "https://data.ssb.no/api/klass/v1/classifications";
 
-    private static final boolean prod = false;
+    private static final boolean prod = true;
 
     public SubsetsController(){
         updateLDSURL();

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -115,12 +115,11 @@ public class SubsetsController {
             if (ldsRE.getStatusCodeValue() != 200){
                 return ldsRE;
             }
-            else if (!ldsRE.getBody().has(0)){
-                return new ResponseEntity<>(HttpStatus.NOT_FOUND);
-            }
-
             JsonNode responseBodyJSON = ldsRE.getBody();
             if (responseBodyJSON != null){
+                if (!responseBodyJSON.has(0)){
+                    return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+                }
                 if (responseBodyJSON.isArray()) {
                     ArrayNode versionsArrayNode = (ArrayNode) responseBodyJSON;
                     Map<Integer, JsonNode> versionLastUpdatedMap = new HashMap<>(versionsArrayNode.size() * 2, 0.51f);

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -128,11 +128,16 @@ public class SubsetsController {
                         JsonNode self = Utils.getSelfLinkObject(mapper, ServletUriComponentsBuilder.fromCurrentRequestUri(), subsetVersionDocument);
                         subsetVersionDocument.set("_links", self);
                         int subsetMajorVersion = Integer.parseInt(subsetVersionDocument.get("version").textValue().split("\\.")[0]);
-                        String lastUpdatedDate = subsetVersionDocument.get("lastUpdatedDate").textValue();
                         if (!versionLastUpdatedMap.containsKey(subsetMajorVersion)){ // Only include the latest update of any major version
                             versionLastUpdatedMap.put(subsetMajorVersion, subsetVersionDocument);
-                        } else if (versionLastUpdatedMap.get(subsetMajorVersion).get("lastUpdatedDate").textValue().compareTo(lastUpdatedDate) < 0) {
-                            versionLastUpdatedMap.put(subsetMajorVersion, subsetVersionDocument);
+                        } else {
+                            if (!subsetVersionDocument.has("lastUpdatedDate")){
+                                subsetVersionDocument.set("lastUpdatedDate", subsetVersionDocument.get("createdDate"));
+                            }
+                            String lastUpdatedDate = subsetVersionDocument.get("lastUpdatedDate").textValue();
+                            if (versionLastUpdatedMap.get(subsetMajorVersion).get("lastUpdatedDate").textValue().compareTo(lastUpdatedDate) < 0) {
+                                versionLastUpdatedMap.put(subsetMajorVersion, subsetVersionDocument);
+                            }
                         }
                     }
                     Set<Integer> keySet = versionLastUpdatedMap.keySet();

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -19,6 +19,7 @@ import java.util.Set;
 @RestController
 public class SubsetsController {
 
+    private static SubsetsController instance;
     private static final Logger LOG = LoggerFactory.getLogger(SubsetsController.class);
 
     static final String LDS_PROD = "http://lds-klass.klass.svc.cluster.local/ns/ClassificationSubset";
@@ -30,7 +31,12 @@ public class SubsetsController {
     private static final boolean prod = true;
 
     public SubsetsController(){
+        instance = this;
         updateLDSURL();
+    }
+
+    public static SubsetsController getInstance(){
+        return instance;
     }
 
     private void updateLDSURL(){

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -165,7 +165,8 @@ public class SubsetsController {
                         majorVersionsArrayNode.add(versionLastUpdatedMap.get(keyArray[i]));
                     }
                     JsonNode latestVersion = Utils.getLatestMajorVersion(majorVersionsArrayNode, false);
-                    // JsonNode latestPublishedVersionNode = Utils.getLatestMajorVersion(majorVersionsArrayNode, true);
+                    JsonNode latestPublishedVersionNode = Utils.getLatestMajorVersion(majorVersionsArrayNode, true);
+                    boolean publishedVersionExists = latestPublishedVersionNode != null;
                     int latestMajorVersion = Integer.parseInt(latestVersion.get("version").asText().split("\\.")[0]);
 
                     ArrayNode majorVersionsObjectNodeArray = mapper.createArrayNode();
@@ -173,12 +174,12 @@ public class SubsetsController {
                         ObjectNode objectNode = versionNode.deepCopy();
                         int version = Integer.parseInt(objectNode.get("version").asText().split("\\.")[0]);
                         objectNode.put("version", version);
-                        if (version < latestMajorVersion && objectNode.get("administrativeStatus").asText().equals("OPEN")){
-                            if (latestVersion.has("name")){
-                                objectNode.set("name", latestVersion.get("name"));
+                        if (publishedVersionExists && version < latestMajorVersion && objectNode.get("administrativeStatus").asText().equals("OPEN")){
+                            if (latestPublishedVersionNode.has("name")){
+                                objectNode.set("name", latestPublishedVersionNode.get("name"));
                             }
-                            if (latestVersion.has("shortName")){
-                                objectNode.set("shortName", latestVersion.get("shortName"));
+                            if (latestPublishedVersionNode.has("shortName")){
+                                objectNode.set("shortName", latestPublishedVersionNode.get("shortName"));
                             }
                         }
                         majorVersionsObjectNodeArray.add(objectNode);

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -30,9 +30,8 @@ public class Utils {
     }
 
     public static JsonNode getSelfLinkObject(ObjectMapper mapper, ServletUriComponentsBuilder servletUriComponentsBuilder, JsonNode subset){
-        String subsetVersion = subset.get("version").textValue().split("\\.")[0];
         ObjectNode hrefNode = mapper.createObjectNode();
-        hrefNode.put("href", servletUriComponentsBuilder.toUriString()+"/"+subsetVersion);
+        hrefNode.put("href", servletUriComponentsBuilder.toUriString());
         ObjectNode self = mapper.createObjectNode();
         self.set("self", hrefNode);
         return self;

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -42,8 +42,7 @@ public class Utils {
         TimeZone tz = TimeZone.getTimeZone("UTC");
         DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'"); // Quoted "Z" to indicate UTC, no timezone offset
         df.setTimeZone(tz);
-        String nowAsISO = df.format(new Date());
-        return nowAsISO;
+        return df.format(new Date());
     }
 
     public static JsonNode cleanSubsetVersion(JsonNode subset){
@@ -66,12 +65,12 @@ public class Utils {
         return clone;
     }
 
-    public static JsonNode getLatestMajorVersion(ArrayNode majorVersionsArrayNode){
+    public static JsonNode getLatestMajorVersion(ArrayNode majorVersionsArrayNode, boolean published){
         JsonNode latestVersionNode = null;
-        int latestVersion = 0;
+        int latestVersion = -1;
         for (JsonNode versionNode : majorVersionsArrayNode) {
             int thisVersion = Integer.parseInt(versionNode.get("version").asText().split("\\.")[0]);
-            if (latestVersionNode == null || thisVersion > latestVersion){
+            if ((!published || versionNode.get("administrativeStatus").asText().equals("OPEN")) && thisVersion > latestVersion ){
                 latestVersionNode = versionNode;
                 latestVersion = thisVersion;
             }

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -31,7 +31,9 @@ public class Utils {
 
     public static JsonNode getSelfLinkObject(ObjectMapper mapper, ServletUriComponentsBuilder servletUriComponentsBuilder, JsonNode subset){
         ObjectNode hrefNode = mapper.createObjectNode();
-        hrefNode.put("href", servletUriComponentsBuilder.toUriString());
+        String urlBase = servletUriComponentsBuilder.toUriString().split("subsets")[0];
+        String resourceUrn = urlBase+"subsets/"+subset.get("id")+"/versions/"+subset.get("version");
+        hrefNode.put("href", resourceUrn);
         ObjectNode self = mapper.createObjectNode();
         self.set("self", hrefNode);
         return self;

--- a/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
@@ -43,7 +43,7 @@ class SubsetsServiceApplicationTests {
 
 	@Test
 	void getIllegalIdSubset() {
-		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubset("this-id-is-not-legal-¤%&#!§|`^¨~'*=)(/\\£$@{[]}");
+		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubset("this-id-is-not-legal-¤%&#!§|`^¨~'*=)(/\\£$@{[]}", false);
 
 		System.out.println("STATUS CODE");
 		System.out.println(response.getStatusCodeValue());
@@ -56,7 +56,7 @@ class SubsetsServiceApplicationTests {
 
 	@Test
 	void getNonExistingSubset() {
-		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubset("this-id-does-not-exist");
+		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubset("this-id-does-not-exist", false);
 
 		System.out.println("STATUS CODE");
 		System.out.println(response.getStatusCodeValue());
@@ -88,7 +88,7 @@ class SubsetsServiceApplicationTests {
 		System.out.println(response.getBody());
 		System.out.println("IDs:");
 		for (JsonNode jsonNode : response.getBody()) {
-			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText()).getBody();
+			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText(), false).getBody();
 			assertEquals(subset.get("id").asText(), jsonNode.get("id").asText());
 			System.out.println(subset.get("id"));
 		}
@@ -102,7 +102,7 @@ class SubsetsServiceApplicationTests {
 		System.out.println(response.getBody());
 		System.out.println("IDs:");
 		for (JsonNode jsonNode : response.getBody()) {
-			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText()).getBody();
+			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText(), false).getBody();
 			assertEquals(subset.get("id").asText(), jsonNode.get("id").asText());
 			System.out.println("ID: "+subset.get("id"));
 

--- a/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
@@ -110,7 +110,7 @@ class SubsetsServiceApplicationTests {
 			assertNotEquals(null, versions);
 			assertNotEquals(0, versions.size());
 			for (JsonNode version : versions) {
-				System.out.println("Version: "+version.get("version").asText());
+				System.out.println("Version: "+version.get("version").asText()+" adminstatus: "+version.get("administrativeStatus").asText()+" name:"+version.get("name").get(0).get("languageText").asText());
 			}
 
 		}


### PR DESCRIPTION
- Versions are correctly ordered in the /versions array, no matter which one was updated last.
- Administration status now affects how names are updated: if latest version is DRAFT, its name will not be applied to previous versions. If the status is OPEN, all previous versions are affected.
- Because of my own code changes and how the LDS timeline api responds (empty 200 OK even if the subset does not exist), appropriate 404 responses were not given for a while. Now they are given correctly, once again.
- Make sure the "id" of the subset is immutable: it can not be updated with a PUT request. 
- Fixed an issue with PUT that arises when no published version exists of a subset, but a draft does exist.
- subset "_self" URN was generated wrong in many cases. I believe it is now correct in all cases. closes #56 
- `subsets/{id}?publishedOnly=true` returns the last published version of a subset. closes #57
- `subsets/{id}/codes?publishedOnly=true` returns the codes of the last published version.
- `subsets/{id}/codes?from=...&to=...&publishedOnly=true` returns codes of published versions valid in that time span
- health and liveness probes at `health/alive` and `health/ready`. closes #58 

closes #54 
closes #53 
If you want to see the description and admin status changes, make sure you are updating the latest version, or that you are requesting the specific version you updated.