### PR TITLE
*actually* add ISO "now" time to created and last updated fields && better error display

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -28,7 +28,7 @@ public class SubsetsController {
 
     private static String KLASS_CLASSIFICATIONS_API = "https://data.ssb.no/api/klass/v1/classifications";
 
-    private static final boolean prod = false;
+    private static final boolean prod = true;
 
     public SubsetsController(){
         instance = this;

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -53,11 +53,20 @@ public class SubsetsController {
     public ResponseEntity<JsonNode> getSubsets() {
         LDSConsumer consumer = new LDSConsumer(LDS_SUBSET_API);
         ResponseEntity<JsonNode> ldsRE = consumer.getFrom("");
-        ArrayNode ldsAllSubsetsArrayNode = (ArrayNode) ldsRE.getBody();
-        for (int i = 0; i < ldsAllSubsetsArrayNode.size(); i++) {
-            ldsAllSubsetsArrayNode.set(i, getVersions(ldsAllSubsetsArrayNode.get(i).get("id").asText()).getBody().get(0));
+
+        JsonNode ldsREBody = ldsRE.getBody();
+        if (ldsRE.getStatusCodeValue() != 400){
+            return ErrorHandler.newHttpError("LDS returned a "+ldsRE.getStatusCodeValue()+" "+ldsRE.getStatusCode().toString(), HttpStatus.INTERNAL_SERVER_ERROR, LOG);
+        } else {
+            if(ldsREBody != null && ldsREBody.isArray()){
+                ArrayNode ldsAllSubsetsArrayNode = (ArrayNode) ldsREBody;
+                for (int i = 0; i < ldsAllSubsetsArrayNode.size(); i++) {
+                    ldsAllSubsetsArrayNode.set(i, getVersions(ldsAllSubsetsArrayNode.get(i).get("id").asText()).getBody().get(0));
+                }
+                return new ResponseEntity<>(ldsAllSubsetsArrayNode, HttpStatus.OK);
+            }
+            return ErrorHandler.newHttpError("LDS returned OK, but a non-array body. This was unexpected.", HttpStatus.INTERNAL_SERVER_ERROR, LOG);
         }
-        return new ResponseEntity<>(ldsAllSubsetsArrayNode, HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -28,7 +28,7 @@ public class SubsetsController {
 
     private static String KLASS_CLASSIFICATIONS_API = "https://data.ssb.no/api/klass/v1/classifications";
 
-    private static final boolean prod = true;
+    private static final boolean prod = false;
 
     public SubsetsController(){
         instance = this;
@@ -71,14 +71,16 @@ public class SubsetsController {
         if (subsetJson != null) {
             JsonNode idJN = subsetJson.get("id");
             String id = idJN.textValue();
-            ObjectNode editableSubset = subsetJson.deepCopy();
-            String isoNow = Utils.getNowISO();
-            editableSubset.put("lastUpdatedDate", isoNow);
-            editableSubset.put("createdDate", isoNow);
             LDSConsumer consumer = new LDSConsumer(LDS_SUBSET_API);
             ResponseEntity<JsonNode> ldsResponse = consumer.getFrom("/"+id);
-            if (ldsResponse.getStatusCodeValue() == 404)
-                return consumer.postTo("/" + id, Utils.cleanSubsetVersion(subsetJson));
+            if (ldsResponse.getStatusCodeValue() == 404){
+                ObjectNode editableSubset = subsetJson.deepCopy();
+                String isoNow = Utils.getNowISO();
+                editableSubset.put("lastUpdatedDate", isoNow);
+                editableSubset.put("createdDate", isoNow);
+                JsonNode cleanSubset = Utils.cleanSubsetVersion(editableSubset);
+                return consumer.postTo("/" + id, cleanSubset);
+            }
         }
         return ErrorHandler.newHttpError("Can not create subset. ID already in use", HttpStatus.BAD_REQUEST, LOG);
     }


### PR DESCRIPTION
MISTAKE: In the POST subset code, I would create an editable copy of the subset and correctly set the "created" and "updated" to ISO now. The editable copy with the correct dates would not be posted, but rather the original subset as submitted by the user.

NOW: Submit the correctly edited copy of the subset submitted by the user.

ALSO: When v1/subsets does not return what we expect, tell the user in a graceful way. BUT: I still have to write this in a GENERAL way that it covers all calls made to LDS, not just the one that's made at v1/subsets.