### PR TITLE
this might do it

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -219,7 +219,7 @@ public class SubsetsController {
                         ObjectNode subsetVersionDocument = versionNode.get("document").deepCopy();
                         JsonNode self = Utils.getSelfLinkObject(mapper, ServletUriComponentsBuilder.fromCurrentRequestUri(), subsetVersionDocument);
                         subsetVersionDocument.set("_links", self);
-                        int subsetMajorVersion = Integer.parseInt(subsetVersionDocument.get("version").textValue().split("\\.")[0]);
+                        int subsetMajorVersion = Integer.parseInt(subsetVersionDocument.get("version").asText().split("\\.")[0]);
                         if (!versionLastUpdatedMap.containsKey(subsetMajorVersion)){ // Only include the latest update of any major version
                             versionLastUpdatedMap.put(subsetMajorVersion, subsetVersionDocument);
                         } else {


### PR DESCRIPTION
I think that a field that is supposed to be String is actually sometimes an int. This can cause a NPE at line 222 in SubsetsController. I think this change makes it so that it casts the int to a string as it is read. That should fix it.