### PR TITLE
Large versioning improvements

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/Field.java
+++ b/src/main/java/no/ssb/subsetsservice/Field.java
@@ -17,5 +17,6 @@ public class Field {
     public static final String ADMINISTRATIVE_STATUS = "administrativeStatus";
     public static final String OPEN = "OPEN";
     public static final String DRAFT = "DRAFT";
+    public static final String LAST_UPDATED_BY = "lastUpdatedBy";
 
 }

--- a/src/main/java/no/ssb/subsetsservice/Field.java
+++ b/src/main/java/no/ssb/subsetsservice/Field.java
@@ -1,0 +1,21 @@
+package no.ssb.subsetsservice;
+
+public class Field {
+    public static final String VALID_FROM = "validFrom";
+    public static final String VALID_UNTIL = "validUntil";
+    public static final String VERSION = "version";
+    public static final String VERSION_VALID_FROM = "versionValidFrom";
+    public static final String VERSION_RATIONALE = "versionRationale";
+    public static final String DOCUMENT = "document";
+    public static final String CODES = "codes";
+    public static final String NAME = "name";
+    public static final String SHORT_NAME = "shortName";
+    public static final String ID = "id";
+    public static final String URN = "urn";
+    public static final String LAST_UPDATED_DATE = "lastUpdatedDate";
+    public static final String CREATED_DATE = "createdDate";
+    public static final String ADMINISTRATIVE_STATUS = "administrativeStatus";
+    public static final String OPEN = "OPEN";
+    public static final String DRAFT = "DRAFT";
+
+}

--- a/src/main/java/no/ssb/subsetsservice/HealthController.java
+++ b/src/main/java/no/ssb/subsetsservice/HealthController.java
@@ -16,7 +16,7 @@ public class HealthController {
 
     @RequestMapping("/health/ready")
     public ResponseEntity<String> ready() {
-        ResponseEntity<JsonNode> responseEntity = SubsetsController.getInstance().getSubsets();
+        ResponseEntity<JsonNode> responseEntity = SubsetsController.getInstance().getSubsets(false, false);
         if (responseEntity.getStatusCodeValue() == 200)
             return new ResponseEntity<>("The service is ready!", HttpStatus.OK);
         return new ResponseEntity<>("The service is not ready yet.", HttpStatus.SERVICE_UNAVAILABLE);

--- a/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
+++ b/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
@@ -25,6 +25,8 @@ public class KlassURNResolver {
         String[] urnSplitColon = codeURN.split(":");
         String classificationID = urnSplitColon[3];
         String code = urnSplitColon[5];
+        from = from.split("T")[0];
+        to = to.split("T")[0];
         String url = makeURL(classificationID, from, to, code);
         ResponseEntity<JsonNode> selectCodesRE = getFrom(url);
         JsonNode codes = selectCodesRE.getBody();
@@ -39,8 +41,11 @@ public class KlassURNResolver {
             String code = urnSplitColon[5];
             classificationCodesMap.merge(classificationID, code, (c1, c2)-> c1+","+c2);
         }
+
+        String fromDate = from.split("T")[0];
+        String toDate = to.split("T")[0];
         List<ArrayNode> codesArrayNodeList = new ArrayList<>();
-        classificationCodesMap.forEach((classification, codes) -> codesArrayNodeList.add((ArrayNode)(getFrom(makeURL(classification, from, to, codes)).getBody().get(Field.CODES))));
+        classificationCodesMap.forEach((classification, codes) -> codesArrayNodeList.add((ArrayNode)(getFrom(makeURL(classification, fromDate, toDate, codes)).getBody().get(Field.CODES))));
         ArrayNode allCodesArrayNode = new ObjectMapper().createArrayNode();
         for (ArrayNode codes : codesArrayNodeList) {
             codes.forEach(allCodesArrayNode::add);

--- a/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
+++ b/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
@@ -34,11 +34,22 @@ public class KlassURNResolver {
     }
 
     public static ArrayNode resolveURNs(List<String> codeURNs, String from, String to){
+        LOG.info("Resolving all code URNs in a subset");
         Map<String, String> classificationCodesMap = new HashMap<>();
         for (String codeURN : codeURNs) {
             String[] urnSplitColon = codeURN.split(":");
-            String classificationID = urnSplitColon[3];
-            String code = urnSplitColon[5];
+            String classificationID = "";
+            String code = "";
+            for (int i = 0; i < urnSplitColon.length; i++) {
+                String value = urnSplitColon[i];
+                if (value.equals("code")){
+                    if (urnSplitColon.length > i+1)
+                        code = urnSplitColon[i+1];
+                } else if (value.equals("classifications")){
+                    if (urnSplitColon.length > i+1)
+                        classificationID = urnSplitColon[i+1];
+                }
+            }
             classificationCodesMap.merge(classificationID, code, (c1, c2)-> c1+","+c2);
         }
 

--- a/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
+++ b/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
@@ -1,0 +1,64 @@
+package no.ssb.subsetsservice;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class KlassURNResolver {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KlassURNResolver.class);
+    public static final String klassBaseURL = "https://data.ssb.no/api/klass/v1/classifications/";
+
+    public static JsonNode resolveURN(String codeURN, String from, String to){
+        LOG.info("Attempting to resolve the KLASS code URN "+codeURN);
+        String[] urnSplitColon = codeURN.split(":");
+        String classificationID = urnSplitColon[3];
+        String code = urnSplitColon[5];
+        String url = makeURL(classificationID, from, to, code);
+        ResponseEntity<JsonNode> selectCodesRE = getFrom(url);
+        JsonNode codes = selectCodesRE.getBody();
+        return codes;
+    }
+
+    public static ArrayNode resolveURNs(List<String> codeURNs, String from, String to){
+        Map<String, String> classificationCodesMap = new HashMap<>();
+        for (String codeURN : codeURNs) {
+            String[] urnSplitColon = codeURN.split(":");
+            String classificationID = urnSplitColon[3];
+            String code = urnSplitColon[5];
+            classificationCodesMap.merge(classificationID, code, (c1, c2)-> c1+","+c2);
+        }
+        List<ArrayNode> codesArrayNodeList = new ArrayList<>();
+        classificationCodesMap.forEach((classification, codes) -> codesArrayNodeList.add((ArrayNode)(getFrom(makeURL(classification, from, to, codes)).getBody().get(Field.CODES))));
+        ArrayNode allCodesArrayNode = new ObjectMapper().createArrayNode();
+        for (ArrayNode codes : codesArrayNodeList) {
+            codes.forEach(allCodesArrayNode::add);
+        }
+        return allCodesArrayNode;
+    }
+
+    private static String makeURL(String classificationID, String from, String to, String codes){
+        return String.format("%s%s/codes.json?from=%s&to=%s&selectCodes=%s", klassBaseURL, classificationID, from, to, codes);
+    }
+
+    static ResponseEntity<JsonNode> getFrom(String url)
+    {
+        LOG.info("Attempting to GET "+url);
+        try {
+            return new RestTemplate().getForEntity(url, JsonNode.class);
+        } catch (HttpClientErrorException | HttpServerErrorException e){
+            return ErrorHandler.newHttpError("could not retrieve "+url+".", e.getStatusCode(), LOG);
+        }
+    }
+}

--- a/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
+++ b/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
@@ -18,9 +18,13 @@ import java.util.Map;
 public class KlassURNResolver {
 
     private static final Logger LOG = LoggerFactory.getLogger(KlassURNResolver.class);
-    public static final String klassBaseURL = "https://data.ssb.no/api/klass/v1/classifications/";
+    public static String klassBaseURL = "https://data.ssb.no/api/klass/v1/classifications/";
 
-    public static JsonNode resolveURN(String codeURN, String from, String to){
+    public static String getURL(){
+        return System.getenv().getOrDefault("API_KLASS", klassBaseURL);
+    }
+
+    public JsonNode resolveURN(String codeURN, String from, String to){
         LOG.info("Attempting to resolve the KLASS code URN "+codeURN);
         String[] urnSplitColon = codeURN.split(":");
         String classificationID = "";
@@ -43,7 +47,7 @@ public class KlassURNResolver {
         return codes;
     }
 
-    public static ArrayNode resolveURNs(List<String> codeURNs, String from, String to) {
+    public ArrayNode resolveURNs(List<String> codeURNs, String from, String to) {
         LOG.info("Resolving all code URNs in a subset");
         Map<String, String> classificationCodesMap = new HashMap<>();
         for (String codeURN : codeURNs) {
@@ -78,11 +82,12 @@ public class KlassURNResolver {
         return allCodesArrayNode;
     }
 
-    private static String makeURL(String classificationID, String from, String to, String codes){
+    private String makeURL(String classificationID, String from, String to, String codes){
+        klassBaseURL = getURL();
         return String.format("%s%s/codes.json?from=%s&to=%s&selectCodes=%s", klassBaseURL, classificationID, from, to, codes);
     }
 
-    static ResponseEntity<JsonNode> getFrom(String url)
+    private ResponseEntity<JsonNode> getFrom(String url)
     {
         LOG.info("Attempting to GET "+url);
         try {

--- a/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
+++ b/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
@@ -55,6 +55,10 @@ public class KlassURNResolver {
 
         String fromDate = from.split("T")[0];
         String toDate = to.split("T")[0];
+
+        if (fromDate.compareTo(toDate) >= 0)
+            throw new IllegalArgumentException("fromDate must be before toDate, but was the same as or after");
+
         List<ArrayNode> codesArrayNodeList = new ArrayList<>();
         classificationCodesMap.forEach((classification, codes) -> codesArrayNodeList.add((ArrayNode)(getFrom(makeURL(classification, fromDate, toDate, codes)).getBody().get(Field.CODES))));
         ArrayNode allCodesArrayNode = new ObjectMapper().createArrayNode();

--- a/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
+++ b/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
@@ -70,8 +70,8 @@ public class KlassURNResolver {
         String fromDate = from.split("T")[0];
         String toDate = to.split("T")[0];
 
-        if (fromDate.compareTo(toDate) >= 0)
-            throw new IllegalArgumentException("fromDate must be before toDate, but was the same as or after");
+        if (fromDate.compareTo(toDate) >= 0 && !toDate.equals(""))
+            throw new IllegalArgumentException("fromDate "+fromDate+" must be before toDate "+toDate+", but was the same as or after the toDate. ");
 
         List<ArrayNode> codesArrayNodeList = new ArrayList<>();
         classificationCodesMap.forEach((classification, codes) -> codesArrayNodeList.add((ArrayNode)(getFrom(makeURL(classification, fromDate, toDate, codes)).getBody().get(Field.CODES))));

--- a/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
+++ b/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
@@ -33,7 +33,7 @@ public class KlassURNResolver {
         return codes;
     }
 
-    public static ArrayNode resolveURNs(List<String> codeURNs, String from, String to){
+    public static ArrayNode resolveURNs(List<String> codeURNs, String from, String to) {
         LOG.info("Resolving all code URNs in a subset");
         Map<String, String> classificationCodesMap = new HashMap<>();
         for (String codeURN : codeURNs) {

--- a/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
+++ b/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
@@ -23,8 +23,18 @@ public class KlassURNResolver {
     public static JsonNode resolveURN(String codeURN, String from, String to){
         LOG.info("Attempting to resolve the KLASS code URN "+codeURN);
         String[] urnSplitColon = codeURN.split(":");
-        String classificationID = urnSplitColon[3];
-        String code = urnSplitColon[5];
+        String classificationID = "";
+        String code = "";
+        for (int i = 0; i < urnSplitColon.length; i++) {
+            String value = urnSplitColon[i];
+            if (value.equals("code")){
+                if (urnSplitColon.length > i+1)
+                    code = urnSplitColon[i+1];
+            } else if (value.equals("classifications")){
+                if (urnSplitColon.length > i+1)
+                    classificationID = urnSplitColon[i+1];
+            }
+        }
         from = from.split("T")[0];
         to = to.split("T")[0];
         String url = makeURL(classificationID, from, to, code);

--- a/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
@@ -13,10 +13,12 @@ import java.util.Collections;
 public class LDSConsumer {
 
     private static final Logger LOG = LoggerFactory.getLogger(LDSConsumer.class);
+    static final String LDS_PROD = "http://lds-klass.klass.svc.cluster.local/ns/ClassificationSubset";
+    static String LDS_LOCAL = "http://localhost:9090/ns/ClassificationSubset";
     static String LDS_URL;
 
-    public LDSConsumer(String ldsSubsetApi) {
-        LDS_URL = ldsSubsetApi;
+    LDSConsumer(){
+        LDS_URL = System.getenv().getOrDefault("API_LDS", LDS_LOCAL);
     }
 
     ResponseEntity<JsonNode> getFrom(String additional)

--- a/src/main/java/no/ssb/subsetsservice/LDSInterface.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSInterface.java
@@ -1,0 +1,57 @@
+package no.ssb.subsetsservice;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LDSInterface {
+
+    public List<String> getAllSubsetIDs() throws HttpClientErrorException {
+
+        ResponseEntity<JsonNode> allSubsetsRE = getLastUpdatedVersionOfAllSubsets();
+
+        if (allSubsetsRE.getStatusCodeValue() == HttpStatus.OK.value()) {
+            JsonNode ldsREBody = allSubsetsRE.getBody();
+            if (ldsREBody != null) {
+                if (ldsREBody.isArray()) {
+                    ArrayNode ldsAllSubsetsArrayNode = (ArrayNode) ldsREBody;
+                    List<String> idList = new ArrayList<>(ldsAllSubsetsArrayNode.size());
+                    for (JsonNode jsonNode : ldsAllSubsetsArrayNode) {
+                        idList.add(jsonNode.get(Field.ID).asText());
+                    }
+                    return idList;
+                }
+            }
+        }
+        throw new HttpClientErrorException(allSubsetsRE.getStatusCode());
+    }
+
+    public ResponseEntity<JsonNode> getLastUpdatedVersionOfAllSubsets(){
+        return new LDSConsumer().getFrom("");
+    }
+
+    public ResponseEntity<JsonNode> getTimelineOfSubset(String id){
+        return new LDSConsumer().getFrom("/"+id+"?timeline");
+    }
+
+    public boolean existsSubsetWithID(String id){
+        return new LDSConsumer().getFrom("/"+id).getStatusCode().equals(HttpStatus.OK);
+    }
+
+    public ResponseEntity<JsonNode> getClassificationSubsetSchema(){
+        return new LDSConsumer().getFrom("/?schema");
+    }
+
+    public ResponseEntity<JsonNode> editSubset(JsonNode subset, String id){
+        return new LDSConsumer().putTo("/" + id, subset);
+    }
+
+    public ResponseEntity<JsonNode> createSubset(JsonNode subset, String id){
+        return new LDSConsumer().postTo("/" + id, subset);
+    }
+}

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -283,8 +283,8 @@ public class SubsetsController {
                     ArrayList<JsonNode> versionList = new ArrayList<>(versionLastUpdatedMap.size());
                     versionLastUpdatedMap.forEach((versionInt, versionJsonNode) -> versionList.add(versionJsonNode));
                     LOG.debug("versionList size: "+versionList.size());
-                    versionList.sort(Comparator.comparing(v -> v.get(Field.VERSION_VALID_FROM).asText())); // TODO: This is sorted wrong way around
-                    String validTo = ""; //TODO: This is a mistake.
+                    versionList.sort((s1, s2) -> s2.get(Field.VERSION_VALID_FROM).asText().compareTo(s1.get(Field.VERSION_VALID_FROM).asText())); // TODO: This is repeated code
+                    String validTo = ""; //TODO: This is potentially a mistake.
                     for (int i = 0; i < versionList.size(); i++) {
                         ObjectNode editableSubset = versionList.get(i).deepCopy();
                         ArrayNode resolvedCodes = resolveURNs(editableSubset, validTo);

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -113,7 +113,7 @@ public class SubsetsController {
     }
 
     @GetMapping("/v1/subsets/{id}")
-    public ResponseEntity<JsonNode> getSubset(@PathVariable("id") String id, @RequestParam(defaultValue = "false") boolean publishedOnly) {
+    public ResponseEntity<JsonNode> getSubset(@PathVariable("id") String id, @RequestParam(defaultValue = "true") boolean publishedOnly) {
         metricsService.incrementGETCounter();
         LOG.info("GET subset with id "+id);
 
@@ -125,7 +125,9 @@ public class SubsetsController {
             if (majorVersionsBody != null && majorVersionsBody.isArray()){
                 ArrayNode majorVersionsArray = (ArrayNode) majorVersionsBody;
                 for (JsonNode version : majorVersionsArray) {
-                    if (!publishedOnly || version.get(Field.ADMINISTRATIVE_STATUS).asText().equals(Field.OPEN)){
+                    String versionValidFrom = version.get(Field.VERSION_VALID_FROM).asText();
+                    String nowDateTime = Utils.getNowISO();
+                    if (versionValidFrom.compareTo(nowDateTime) < 0 && (!publishedOnly || version.get(Field.ADMINISTRATIVE_STATUS).asText().equals(Field.OPEN))){
                         return new ResponseEntity<>(majorVersionsArray.get(0), HttpStatus.OK);
                     }
                 }
@@ -394,7 +396,7 @@ public class SubsetsController {
      * @return
      */
     @GetMapping("/v1/subsets/{id}/codes")
-    public ResponseEntity<JsonNode> getSubsetCodes(@PathVariable("id") String id, @RequestParam(required = false) String from, @RequestParam(required = false) String to, @RequestParam(defaultValue = "false") boolean publishedOnly) {
+    public ResponseEntity<JsonNode> getSubsetCodes(@PathVariable("id") String id, @RequestParam(required = false) String from, @RequestParam(required = false) String to, @RequestParam(defaultValue = "true") boolean publishedOnly) {
         LOG.info("GET codes of subset with id "+id);
         metricsService.incrementGETCounter();
 

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -28,7 +28,7 @@ public class SubsetsController {
 
     private static String KLASS_CLASSIFICATIONS_API = "https://data.ssb.no/api/klass/v1/classifications";
 
-    private static final boolean prod = true;
+    private static final boolean prod = false;
 
     @Autowired
     public SubsetsController(MetricsService metricsService){
@@ -563,7 +563,7 @@ public class SubsetsController {
             ArrayNode codesArrayNode = KlassURNResolver.resolveURNs(codeURNs, versionValidFrom, to);
             return codesArrayNode;
         } catch (Exception | Error e){
-            LOG.info("Could not resolve code URNs against KLASS. Returning subset with URNs only.");
+            LOG.error(e.toString());
             return codes;
         }
     }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -284,10 +284,13 @@ public class SubsetsController {
                     LOG.debug("versionList size: "+versionList.size());
                     versionList.sort(Comparator.comparing(v -> v.get(Field.VERSION_VALID_FROM).asText())); // TODO: This is sorted wrong way around
                     String validTo = ""; //TODO: This is a mistake.
-                    for (JsonNode jsonNode : versionList) {
-                        ObjectNode editableSubset = jsonNode.deepCopy();
-                        editableSubset.set(Field.CODES, resolveURNs(editableSubset, validTo));
+                    for (int i = 0; i < versionList.size(); i++) {
+                        ObjectNode editableSubset = versionList.get(i).deepCopy();
+                        ArrayNode resolvedCodes = resolveURNs(editableSubset, validTo);
+                        ArrayNode currentCodeList = editableSubset.get(Field.CODES).deepCopy();
+                        editableSubset.set(Field.CODES, resolvedCodes);
                         validTo = editableSubset.get(Field.VERSION_VALID_FROM).asText();
+                        versionList.set(i, editableSubset.deepCopy());
                     }
                     LOG.debug("URNs are resolved");
 
@@ -551,7 +554,9 @@ public class SubsetsController {
             String versionValidFrom = subset.get(Field.VERSION_VALID_FROM).asText();
             versionValidFrom = versionValidFrom.split("T")[0];
             try {
-                return new KlassURNResolver().resolveURNs(codeURNs, versionValidFrom, to);
+                ArrayNode codeURNArrayNode = new KlassURNResolver().resolveURNs(codeURNs, versionValidFrom, to);
+                System.out.println(codeURNArrayNode.toPrettyString());
+                return codeURNArrayNode;
             } catch (Exception | Error e){
                 LOG.error(e.toString());
                 return codes;

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -283,7 +283,7 @@ public class SubsetsController {
                     ArrayList<JsonNode> versionList = new ArrayList<>(versionLastUpdatedMap.size());
                     versionLastUpdatedMap.forEach((versionInt, versionJsonNode) -> versionList.add(versionJsonNode));
                     LOG.debug("versionList size: "+versionList.size());
-                    versionList.sort((s1, s2) -> s2.get(Field.VERSION_VALID_FROM).asText().compareTo(s1.get(Field.VERSION_VALID_FROM).asText())); // TODO: This is repeated code
+                    versionList.sort(Utils::versionComparator);
                     String validTo = ""; //TODO: This is potentially a mistake.
                     for (int i = 0; i < versionList.size(); i++) {
                         ObjectNode editableSubset = versionList.get(i).deepCopy();

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -113,7 +113,7 @@ public class SubsetsController {
     }
 
     @GetMapping("/v1/subsets/{id}")
-    public ResponseEntity<JsonNode> getSubset(@PathVariable("id") String id, @RequestParam(defaultValue = "true") boolean publishedOnly) {
+    public ResponseEntity<JsonNode> getSubset(@PathVariable("id") String id, @RequestParam(defaultValue = "true") boolean publishedOnly, @RequestParam(defaultValue = "false") boolean includeFuture) {
         metricsService.incrementGETCounter();
         LOG.info("GET subset with id "+id);
 
@@ -146,7 +146,7 @@ public class SubsetsController {
         if (Utils.isClean(id)) {
             ObjectNode editableSubset = Utils.cleanSubsetVersion(newVersionOfSubset).deepCopy();
             editableSubset.put(Field.LAST_UPDATED_DATE, Utils.getNowISO());
-            ResponseEntity<JsonNode> mostRecentVersionRE = getSubset(id, false);
+            ResponseEntity<JsonNode> mostRecentVersionRE = getSubset(id, false, true);
             ResponseEntity<JsonNode> oldVersionsRE = getVersions(id);
             JsonNode mostRecentVersionOfThisSubset = mostRecentVersionRE.getBody();
             if (mostRecentVersionRE.getStatusCodeValue() == HttpStatus.OK.value()){
@@ -396,14 +396,14 @@ public class SubsetsController {
      * @return
      */
     @GetMapping("/v1/subsets/{id}/codes")
-    public ResponseEntity<JsonNode> getSubsetCodes(@PathVariable("id") String id, @RequestParam(required = false) String from, @RequestParam(required = false) String to, @RequestParam(defaultValue = "true") boolean publishedOnly) {
+    public ResponseEntity<JsonNode> getSubsetCodes(@PathVariable("id") String id, @RequestParam(required = false) String from, @RequestParam(required = false) String to, @RequestParam(defaultValue = "true") boolean publishedOnly, @RequestParam(defaultValue = "false") boolean includeFuture) {
         LOG.info("GET codes of subset with id "+id);
         metricsService.incrementGETCounter();
 
         if (Utils.isClean(id)){
             if (from == null && to == null){
                 LOG.debug("getting all codes of the latest/current version of subset "+id);
-                ResponseEntity<JsonNode> subsetResponseEntity = getSubset(id, publishedOnly);
+                ResponseEntity<JsonNode> subsetResponseEntity = getSubset(id, publishedOnly, includeFuture);
                 JsonNode responseBodyJSON = subsetResponseEntity.getBody();
                 if (responseBodyJSON != null){
                     ArrayNode codes = (ArrayNode) responseBodyJSON.get(Field.CODES);

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -198,22 +198,17 @@ public class SubsetsController {
                             return ErrorHandler.newHttpError("The submitted version does not contain all the same fields as the already published version that it attempts to override", HttpStatus.BAD_REQUEST, LOG);
                         }
 
-                        boolean allSameValuesExceptValidUntilAndVersionRationale = true;
                         newPatchFieldNames = subsetJson.fieldNames();
-                        while (allSameValuesExceptValidUntilAndVersionRationale && newPatchFieldNames.hasNext()){
+                        while (newPatchFieldNames.hasNext()){
                             String field = newPatchFieldNames.next();
                             String[] changeableFields = {"versionRationale", "validUntil", "lastUpdatedBy", "lastUpdatedDate"};
                             ArrayList<String> changeableFieldsList = new ArrayList<>();
                             Collections.addAll(changeableFieldsList, changeableFields);
                             if (!changeableFieldsList.contains(field)){
                                 if (!prevPatchOfThisVersion.get(field).asText().equals(subsetJson.get(field).asText())) {
-                                    allSameValuesExceptValidUntilAndVersionRationale = false;
+                                    return ErrorHandler.newHttpError("The version of the subset you are trying to change is published, which means you can only change validUntil and versionRationale.", HttpStatus.BAD_REQUEST, LOG);
                                 }
                             }
-                        }
-
-                        if (!allSameValuesExceptValidUntilAndVersionRationale){
-                            return ErrorHandler.newHttpError("The version of the subset you are trying to change is published, which means you can only change validUntil and versionRationale.", HttpStatus.BAD_REQUEST, LOG);
                         }
                     }
                 }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -28,7 +28,7 @@ public class SubsetsController {
 
     private static String KLASS_CLASSIFICATIONS_API = "https://data.ssb.no/api/klass/v1/classifications";
 
-    private static final boolean prod = false;
+    private static final boolean prod = true;
 
     @Autowired
     public SubsetsController(MetricsService metricsService){
@@ -555,17 +555,20 @@ public class SubsetsController {
     }
 
     private ArrayNode resolveURNs(JsonNode subset, String to){
-        ArrayNode codes = (ArrayNode)subset.get(Field.CODES);
-        List<String> codeURNs = new ArrayList<>(codes.size());
-        codes.forEach(c->codeURNs.add(c.get(Field.URN).asText()));
-        String versionValidFrom = subset.get(Field.VERSION_VALID_FROM).asText();
-        try {
-            ArrayNode codesArrayNode = KlassURNResolver.resolveURNs(codeURNs, versionValidFrom, to);
-            return codesArrayNode;
-        } catch (Exception | Error e){
-            LOG.error(e.toString());
-            return codes;
+        if (to.equals("") || Utils.isYearMonthDay(to)){
+            ArrayNode codes = (ArrayNode)subset.get(Field.CODES);
+            List<String> codeURNs = new ArrayList<>(codes.size());
+            codes.forEach(c->codeURNs.add(c.get(Field.URN).asText()));
+            String versionValidFrom = subset.get(Field.VERSION_VALID_FROM).asText();
+            try {
+                ArrayNode codesArrayNode = KlassURNResolver.resolveURNs(codeURNs, versionValidFrom, to);
+                return codesArrayNode;
+            } catch (Exception | Error e){
+                LOG.error(e.toString());
+                return codes;
+            }
         }
+        throw new IllegalArgumentException("'to' must be empty string or on the form YYYY-MM-DD");
     }
 
 }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -171,10 +171,10 @@ public class SubsetsController {
                     boolean thisVersionIsPublishedFromBefore = prevPatchOfThisVersion.get("administrativeStatus").asText().equals("OPEN");
 
                     if (thisVersionIsPublishedFromBefore){
-                        JsonNode oldCodeList = prevPatchOfThisVersion.get("codes");
-                        JsonNode newCodeList = subsetJson.get("codes");
-                        boolean sameCodeList = oldCodeList.toString().equals(newCodeList.toString());
-                        attemptToChangeCodesOfPublishedVersion = thisVersionIsPublishedFromBefore && !sameCodeList;
+                        String oldCodeList = prevPatchOfThisVersion.get("codes").asText();
+                        String newCodeList = subsetJson.get("codes").asText();
+                        boolean differentCodeList = oldCodeList.equals(newCodeList);
+                        attemptToChangeCodesOfPublishedVersion = !differentCodeList;
 
                         Iterator<String> prevPatchFieldNames = prevPatchOfThisVersion.fieldNames();
                         Iterator<String> newPatchFieldNames = subsetJson.fieldNames();

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -202,7 +202,10 @@ public class SubsetsController {
                         newPatchFieldNames = subsetJson.fieldNames();
                         while (allSameValuesExceptValidUntilAndVersionRationale && newPatchFieldNames.hasNext()){
                             String field = newPatchFieldNames.next();
-                            if (! (field.equals("validUntil") || field.equals("versionRationale"))){
+                            String[] changeableFields = {"versionRationale", "validUntil", "lastUpdatedBy", "lastUpdatedDate"};
+                            ArrayList<String> changeableFieldsList = new ArrayList<>();
+                            Collections.addAll(changeableFieldsList, changeableFields);
+                            if (!changeableFieldsList.contains(field)){
                                 if (!prevPatchOfThisVersion.get(field).asText().equals(subsetJson.get(field).asText())) {
                                     allSameValuesExceptValidUntilAndVersionRationale = false;
                                 }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -525,11 +525,13 @@ public class SubsetsController {
     }
 
     private ArrayNode resolveURNs(JsonNode subset, String to){
+        to = to.split("T")[0];
         if (to.equals("") || Utils.isYearMonthDay(to)){
             ArrayNode codes = (ArrayNode)subset.get(Field.CODES);
             List<String> codeURNs = new ArrayList<>(codes.size());
             codes.forEach(c->codeURNs.add(c.get(Field.URN).asText()));
             String versionValidFrom = subset.get(Field.VERSION_VALID_FROM).asText();
+            versionValidFrom = versionValidFrom.split("T")[0];
             try {
                 return new KlassURNResolver().resolveURNs(codeURNs, versionValidFrom, to);
             } catch (Exception | Error e){
@@ -537,7 +539,7 @@ public class SubsetsController {
                 return codes;
             }
         }
-        throw new IllegalArgumentException("'to' must be empty string or on the form YYYY-MM-DD");
+        throw new IllegalArgumentException("'to' must be empty string or on the form YYYY-MM-DD, but was "+to);
     }
 
 }

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -98,7 +98,7 @@ public class Utils {
     public static ArrayNode sortByVersionValidFrom(ArrayNode subsetArrayNode){
         List<JsonNode> subsetList = new ArrayList<>(subsetArrayNode.size());
         subsetArrayNode.forEach(subsetList::add);
-        subsetList.sort((s1, s2) -> s2.get(Field.VERSION_VALID_FROM).asText().compareTo(s1.get(Field.VERSION_VALID_FROM).asText()));
+        subsetList.sort((s1, s2) -> s1.get(Field.VERSION_VALID_FROM).asText().compareTo(s2.get(Field.VERSION_VALID_FROM).asText()));
         ArrayNode newArrayNode = new ObjectMapper().createArrayNode();
         subsetList.forEach(newArrayNode::add);
         return newArrayNode;

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -98,7 +98,7 @@ public class Utils {
     public static ArrayNode sortByVersionValidFrom(ArrayNode subsetArrayNode){
         List<JsonNode> subsetList = new ArrayList<>(subsetArrayNode.size());
         subsetArrayNode.forEach(subsetList::add);
-        subsetList.sort((s1, s2) -> s1.get(Field.VERSION_VALID_FROM).asText().compareTo(s2.get(Field.VERSION_VALID_FROM).asText()));
+        subsetList.sort((s1, s2) -> s2.get(Field.VERSION_VALID_FROM).asText().compareTo(s1.get(Field.VERSION_VALID_FROM).asText()));
         ArrayNode newArrayNode = new ObjectMapper().createArrayNode();
         subsetList.forEach(newArrayNode::add);
         return newArrayNode;

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -17,22 +17,27 @@ import java.util.TimeZone;
 
 public class Utils {
 
+    public static final String ISO_DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss'Z'"; // Quoted "Z" to indicate UTC, no timezone offset
+    public static final String CLEAN_ID_REGEX = "^[a-zA-Z0-9-_]+$";
+    public static final String YEAR_MONTH_DAY_REGEX = "([12]\\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01]))";
+    public static final String VERSION_STRING_REGEX = "(\\d(\\.\\d)?(\\.\\d)?)";
+
     public static boolean isYearMonthDay(String date){
-        return date.matches("([12]\\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01]))");
+        return date.matches(YEAR_MONTH_DAY_REGEX);
     }
 
     public static boolean isVersion(String version){
-        return version.matches("(\\d(\\.\\d)?(\\.\\d)?)");
+        return version.matches(VERSION_STRING_REGEX);
     }
 
     public static boolean isClean(String str){
-        return str.matches("^[a-zA-Z0-9-_]+$");
+        return str.matches(CLEAN_ID_REGEX);
     }
 
     public static JsonNode getSelfLinkObject(ObjectMapper mapper, ServletUriComponentsBuilder servletUriComponentsBuilder, JsonNode subset){
         ObjectNode hrefNode = mapper.createObjectNode();
         String urlBase = servletUriComponentsBuilder.toUriString().split("subsets")[0];
-        String resourceUrn = urlBase+"subsets/"+subset.get("id")+"/versions/"+subset.get("version");
+        String resourceUrn = urlBase+"subsets/"+subset.get("id")+"/versions/"+subset.get(Field.VERSION);
         hrefNode.put("href", resourceUrn);
         ObjectNode self = mapper.createObjectNode();
         self.set("self", hrefNode);
@@ -41,7 +46,7 @@ public class Utils {
 
     public static String getNowISO(){
         TimeZone tz = TimeZone.getTimeZone("UTC");
-        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'"); // Quoted "Z" to indicate UTC, no timezone offset
+        DateFormat df = new SimpleDateFormat(ISO_DATETIME_PATTERN);
         df.setTimeZone(tz);
         return df.format(new Date());
     }
@@ -52,9 +57,9 @@ public class Utils {
             return cleanSubsetVersionsArray(arrayNode);
         }
         ObjectNode clone = subset.deepCopy();
-        String oldVersion = clone.get("version").asText();
+        String oldVersion = clone.get(Field.VERSION).asText();
         String majorVersion = oldVersion.split("\\.")[0];
-        clone.put("version", majorVersion);
+        clone.put(Field.VERSION, majorVersion);
         return clone;
     }
 
@@ -70,12 +75,12 @@ public class Utils {
         JsonNode latestVersionNode = null;
         String latestVersionValidFrom = "0";
         for (JsonNode versionNode : majorVersionsArrayNode) {
-            String thisVersionValidFrom = versionNode.get("versionValidFrom").asText();
-            boolean isOpen = versionNode.get("administrativeStatus").asText().equals("OPEN");
+            String thisVersionValidFrom = versionNode.get(Field.VERSION_VALID_FROM).asText();
+            boolean isOpen = versionNode.get(Field.ADMINISTRATIVE_STATUS).asText().equals(Field.OPEN);
             int compareThisToLatest = thisVersionValidFrom.compareTo(latestVersionValidFrom);
             if (compareThisToLatest == 0){
                 Logger logger = LoggerFactory.getLogger(Utils.class);
-                logger.error("Two major versions of a subset have the same 'versionValidFrom' values. The versions are '"+versionNode.get("version")+"' and '"+latestVersionNode.get("version")+"'");
+                logger.error("Two major versions of a subset have the same 'versionValidFrom' values. The versions are '"+versionNode.get(Field.VERSION)+"' and '"+latestVersionNode.get(Field.VERSION)+"'");
             }
             if ((!published || isOpen) && thisVersionValidFrom.compareTo(latestVersionValidFrom) > 0 ){
                 latestVersionNode = versionNode;
@@ -85,10 +90,15 @@ public class Utils {
         return latestVersionNode;
     }
 
+    /**
+     * Sort an ArrayNode of versions according to their versionValidFrom fields
+     * @param subsetArrayNode
+     * @return
+     */
     public static ArrayNode sortByVersionValidFrom(ArrayNode subsetArrayNode){
         List<JsonNode> subsetList = new ArrayList<>(subsetArrayNode.size());
         subsetArrayNode.forEach(subsetList::add);
-        subsetList.sort((s1, s2) -> s2.get("versionValidFrom").asText().compareTo(s1.get("versionValidFrom").asText()));
+        subsetList.sort((s1, s2) -> s2.get(Field.VERSION_VALID_FROM).asText().compareTo(s1.get(Field.VERSION_VALID_FROM).asText()));
         ArrayNode newArrayNode = new ObjectMapper().createArrayNode();
         subsetList.forEach(newArrayNode::add);
         return newArrayNode;

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -104,4 +104,24 @@ public class Utils {
         return newArrayNode;
     }
 
+    public static boolean isNumeric(String string){
+        if (string == null)
+            return false;
+
+        try {
+            Double.parseDouble(string);
+            return true;
+        } catch (NumberFormatException e){
+            return false;
+        }
+    }
+
+    public static boolean isInteger(String string){
+        if (isNumeric(string)){
+            double d = Double.parseDouble(string);
+            return (d % 1) == 0 && !Double.isInfinite(d);
+        }
+        return false;
+    }
+
 }

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -10,10 +10,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.TimeZone;
+import java.util.*;
 
 public class Utils {
 
@@ -98,7 +95,7 @@ public class Utils {
     public static ArrayNode sortByVersionValidFrom(ArrayNode subsetArrayNode){
         List<JsonNode> subsetList = new ArrayList<>(subsetArrayNode.size());
         subsetArrayNode.forEach(subsetList::add);
-        subsetList.sort((s1, s2) -> s2.get(Field.VERSION_VALID_FROM).asText().compareTo(s1.get(Field.VERSION_VALID_FROM).asText()));
+        subsetList.sort(Utils::versionComparator);
         ArrayNode newArrayNode = new ObjectMapper().createArrayNode();
         subsetList.forEach(newArrayNode::add);
         return newArrayNode;
@@ -122,6 +119,10 @@ public class Utils {
             return (d % 1) == 0 && !Double.isInfinite(d);
         }
         return false;
+    }
+
+    public static int versionComparator(JsonNode s1, JsonNode s2){
+        return s2.get(Field.VERSION_VALID_FROM).asText().compareTo(s1.get(Field.VERSION_VALID_FROM).asText());
     }
 
 }

--- a/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
@@ -15,7 +15,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 class SubsetsServiceApplicationTests {
 
 	private static final Logger LOG = LoggerFactory.getLogger(SubsetsServiceApplicationTests.class);
-	String ldsURL = SubsetsController.LDS_LOCAL;
 
 	@Test
 	void logTest(){

--- a/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
@@ -1,8 +1,6 @@
 package no.ssb.subsetsservice;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -30,7 +28,7 @@ class SubsetsServiceApplicationTests {
 
 	@Test
 	void getAllSubsets() {
-		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubsets();
+		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubsets(true, true);
 
 		assertEquals(200, response.getStatusCodeValue());
 		System.out.println("RESPONSE HEADERS:");
@@ -69,7 +67,7 @@ class SubsetsServiceApplicationTests {
 
 	@Test
 	void getNonExistantSubsetVersions() {
-		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getVersions("this-id-does-not-exist");
+		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getVersions("this-id-does-not-exist", true, true);
 
 		System.out.println("STATUS CODE");
 		System.out.println(response.getStatusCodeValue());
@@ -82,7 +80,7 @@ class SubsetsServiceApplicationTests {
 
 	@Test
 	void getAllIndividualSubsetsCompareIDs() {
-		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubsets();
+		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubsets(true, true);
 
 		System.out.println("All subsets:");
 		System.out.println(response.getBody());
@@ -96,7 +94,7 @@ class SubsetsServiceApplicationTests {
 
 	@Test
 	void getAllVersionsOfAllSubsets() {
-		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubsets();
+		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubsets( true, true);
 
 		System.out.println("All subsets:");
 		System.out.println(response.getBody());
@@ -106,7 +104,7 @@ class SubsetsServiceApplicationTests {
 			assertEquals(subset.get("id").asText(), jsonNode.get("id").asText());
 			System.out.println("ID: "+subset.get("id"));
 
-			ArrayNode versions = (ArrayNode) SubsetsController.getInstance().getVersions(subset.get("id").asText()).getBody();
+			ArrayNode versions = (ArrayNode) SubsetsController.getInstance().getVersions(subset.get("id").asText(), true, true).getBody();
 			assertNotEquals(null, versions);
 			assertNotEquals(0, versions.size());
 			for (JsonNode version : versions) {

--- a/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
@@ -43,7 +43,7 @@ class SubsetsServiceApplicationTests {
 
 	@Test
 	void getIllegalIdSubset() {
-		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubset("this-id-is-not-legal-¤%&#!§|`^¨~'*=)(/\\£$@{[]}", false);
+		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubset("this-id-is-not-legal-¤%&#!§|`^¨~'*=)(/\\£$@{[]}", false, false);
 
 		System.out.println("STATUS CODE");
 		System.out.println(response.getStatusCodeValue());
@@ -56,7 +56,7 @@ class SubsetsServiceApplicationTests {
 
 	@Test
 	void getNonExistingSubset() {
-		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubset("this-id-does-not-exist", false);
+		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubset("this-id-does-not-exist", false, false);
 
 		System.out.println("STATUS CODE");
 		System.out.println(response.getStatusCodeValue());
@@ -88,7 +88,7 @@ class SubsetsServiceApplicationTests {
 		System.out.println(response.getBody());
 		System.out.println("IDs:");
 		for (JsonNode jsonNode : response.getBody()) {
-			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText(), false).getBody();
+			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText(), false, false).getBody();
 			assertEquals(subset.get("id").asText(), jsonNode.get("id").asText());
 			System.out.println(subset.get("id"));
 		}
@@ -102,7 +102,7 @@ class SubsetsServiceApplicationTests {
 		System.out.println(response.getBody());
 		System.out.println("IDs:");
 		for (JsonNode jsonNode : response.getBody()) {
-			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText(), false).getBody();
+			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText(), false, false).getBody();
 			assertEquals(subset.get("id").asText(), jsonNode.get("id").asText());
 			System.out.println("ID: "+subset.get("id"));
 


### PR DESCRIPTION
- Fixed a bug that would make it so that the versions list would not be sorted by versionValidFrom descending, as it is supposed to. This bug would also cause old versions to be returned when asking for subset by ID.
- As default, when requesting a subset by ID you get the latest version that has a published date before the current date. (In other words, don't return a version that is not valid yet, even if it is published). 
- The request parameter includeFuture can be set to "true" to get the very latest version of a subset even if it is valid from the future only, or to include even future subsets/versions in a list of versions.
- The request parameter includeDrafts can be set to "true" to include versions that are not published, or get the latest version despite it not being published.
- Only certain fields can be changed after a version is published: versionRationale, validUntil, lastUpdatedBy, lastUpdatedDate. lastUpdatedDate is set automatically by the service. (To change other fields than these, you must create a new version of the subset.)
- If a new version is added before the previous first version, validFrom must be updated to the same value.
- Resolving URNs pointing to codes from KLASS, and inserting the full codes into our subset before we return them. (Right now it fails on my machine because the data in my LDS contains a lot of illegal fields across versions. I have implemented a failsafe that makes it so that if the URNs fail to resolve for example because KLASS does not answer, we just get the URN list as before in our subsets. I am going to make. In the future I want to make an automated script for wiping LDS and populating it with a diversity of legal versioned subsets, so I can test that my code works on legal subset versions)
- Use predefined variables on the form `public static final String NAME = "name"` when getting certain subset fields by name: This way we avoid errors because of typos in strings that are repeated by hand many places.