### PR TITLE
health check ready improvement

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/HealthController.java
+++ b/src/main/java/no/ssb/subsetsservice/HealthController.java
@@ -16,9 +16,11 @@ public class HealthController {
 
     @RequestMapping("/health/ready")
     public ResponseEntity<String> ready() {
-        ResponseEntity<JsonNode> responseEntity = SubsetsController.getInstance().getSubsets(false, false);
-        if (responseEntity.getStatusCodeValue() == 200)
+        ResponseEntity<JsonNode> getSubsetsResponseEntity = SubsetsController.getInstance().getSubsets(false, false);
+        boolean klassReady = new KlassURNResolver().pingKLASSClassifications();
+        boolean ldsReady = new LDSFacade().pingLDSSubsets();
+        if (klassReady && ldsReady && getSubsetsResponseEntity.getStatusCode().equals(HttpStatus.OK))
             return new ResponseEntity<>("The service is ready!", HttpStatus.OK);
-        return new ResponseEntity<>("The service is not ready yet.", HttpStatus.SERVICE_UNAVAILABLE);
+        return new ResponseEntity<>("The service is not ready yet.\n KLASS ready: "+klassReady+" \n", HttpStatus.SERVICE_UNAVAILABLE);
     }
 }

--- a/src/main/java/no/ssb/subsetsservice/HealthController.java
+++ b/src/main/java/no/ssb/subsetsservice/HealthController.java
@@ -18,7 +18,8 @@ public class HealthController {
     public ResponseEntity<String> ready() {
         boolean klassReady = new KlassURNResolver().pingKLASSClassifications();
         boolean ldsReady = new LDSFacade().pingLDSSubsets();
-        if (klassReady && ldsReady)
+        boolean schemaPresent = new LDSFacade().getClassificationSubsetSchema().getStatusCode().equals(HttpStatus.OK);
+        if (klassReady && ldsReady && schemaPresent)
             return new ResponseEntity<>("The service is ready!", HttpStatus.OK);
         return new ResponseEntity<>("The service is not ready yet.\n KLASS ready: "+klassReady+" \n", HttpStatus.SERVICE_UNAVAILABLE);
     }

--- a/src/main/java/no/ssb/subsetsservice/HealthController.java
+++ b/src/main/java/no/ssb/subsetsservice/HealthController.java
@@ -16,10 +16,9 @@ public class HealthController {
 
     @RequestMapping("/health/ready")
     public ResponseEntity<String> ready() {
-        ResponseEntity<JsonNode> getSubsetsResponseEntity = SubsetsController.getInstance().getSubsets(false, false);
         boolean klassReady = new KlassURNResolver().pingKLASSClassifications();
         boolean ldsReady = new LDSFacade().pingLDSSubsets();
-        if (klassReady && ldsReady && getSubsetsResponseEntity.getStatusCode().equals(HttpStatus.OK))
+        if (klassReady && ldsReady)
             return new ResponseEntity<>("The service is ready!", HttpStatus.OK);
         return new ResponseEntity<>("The service is not ready yet.\n KLASS ready: "+klassReady+" \n", HttpStatus.SERVICE_UNAVAILABLE);
     }

--- a/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
+++ b/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
@@ -21,31 +22,13 @@ public class KlassURNResolver {
     private static final Logger LOG = LoggerFactory.getLogger(KlassURNResolver.class);
     public static String klassBaseURL = "https://data.ssb.no/api/klass/v1/classifications";
 
-    public static String getURL(){
-        return System.getenv().getOrDefault("API_KLASS", klassBaseURL);
+    public boolean pingKLASSClassifications(){
+        ResponseEntity<JsonNode> re = getFrom(klassBaseURL+".json");
+        return re.getStatusCode().equals(HttpStatus.OK);
     }
 
-    public JsonNode resolveURN(String codeURN, String from, String to){
-        LOG.info("Attempting to resolve the KLASS code URN "+codeURN);
-        String[] urnSplitColon = codeURN.split(":");
-        String classificationID = "";
-        String code = "";
-        for (int i = 0; i < urnSplitColon.length; i++) {
-            String value = urnSplitColon[i];
-            if (value.equals("code")){
-                if (urnSplitColon.length > i+1)
-                    code = urnSplitColon[i+1];
-            } else if (value.equals("classifications")){
-                if (urnSplitColon.length > i+1)
-                    classificationID = urnSplitColon[i+1];
-            }
-        }
-        from = from.split("T")[0];
-        to = to.split("T")[0];
-        String url = makeURL(classificationID, from, to, code);
-        ResponseEntity<JsonNode> selectCodesRE = getFrom(url);
-        JsonNode codes = selectCodesRE.getBody();
-        return codes;
+    public static String getURL(){
+        return System.getenv().getOrDefault("API_KLASS", klassBaseURL);
     }
 
     /**
@@ -58,8 +41,6 @@ public class KlassURNResolver {
         LOG.info("Resolving all code URNs in a subset");
 
         ArrayNode codes = (ArrayNode)subset.get(Field.CODES);
-        List<String> codeURNs = new ArrayList<>(codes.size());
-        codes.forEach(c->codeURNs.add(c.get(Field.URN).asText()));
         String from = subset.get(Field.VERSION_VALID_FROM).asText();
         String fromDate = from.split("T")[0];
         String toDate = to.split("T")[0];

--- a/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
+++ b/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
@@ -23,7 +23,7 @@ public class KlassURNResolver {
     public static String klassBaseURL = "https://data.ssb.no/api/klass/v1/classifications";
 
     public boolean pingKLASSClassifications(){
-        ResponseEntity<JsonNode> re = getFrom(klassBaseURL+".json");
+        ResponseEntity<String> re = getStringResponseFrom("https://data.ssb.no/api/klass/ping/");
         return re.getStatusCode().equals(HttpStatus.OK);
     }
 
@@ -109,6 +109,16 @@ public class KlassURNResolver {
             return new RestTemplate().getForEntity(url, JsonNode.class);
         } catch (HttpClientErrorException | HttpServerErrorException e){
             return ErrorHandler.newHttpError("could not retrieve "+url+".", e.getStatusCode(), LOG);
+        }
+    }
+
+    private ResponseEntity<String> getStringResponseFrom(String url)
+    {
+        LOG.info("Attempting to GET "+url);
+        try {
+            return new RestTemplate().getForEntity(url, String.class);
+        } catch (HttpClientErrorException | HttpServerErrorException e){
+            return new ResponseEntity<>(e.toString(), e.getStatusCode());
         }
     }
 }

--- a/src/main/java/no/ssb/subsetsservice/LDSFacade.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSFacade.java
@@ -62,4 +62,9 @@ public class LDSFacade implements LDSInterface {
     public ResponseEntity<JsonNode> createSubset(JsonNode subset, String id){
         return new LDSConsumer(API_LDS).postTo("/" + id, subset);
     }
+
+    @Override
+    public boolean pingLDSSubsets() {
+        return getLastUpdatedVersionOfAllSubsets().getStatusCode().equals(HttpStatus.OK);
+    }
 }

--- a/src/main/java/no/ssb/subsetsservice/LDSFacade.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSFacade.java
@@ -65,6 +65,6 @@ public class LDSFacade implements LDSInterface {
 
     @Override
     public boolean pingLDSSubsets() {
-        return getLastUpdatedVersionOfAllSubsets().getStatusCode().equals(HttpStatus.OK);
+        return new LDSConsumer("https://lds-klass.staging-bip-app.ssb.no/health/ready").getFrom("").getStatusCode().equals(HttpStatus.OK);
     }
 }

--- a/src/main/java/no/ssb/subsetsservice/LDSInterface.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSInterface.java
@@ -64,4 +64,5 @@ public interface LDSInterface {
      */
     ResponseEntity<JsonNode> createSubset(JsonNode subset, String id);
 
+    boolean pingLDSSubsets();
 }

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -18,6 +18,7 @@ public class Utils {
     public static final String CLEAN_ID_REGEX = "^[a-zA-Z0-9-_]+$";
     public static final String YEAR_MONTH_DAY_REGEX = "([12]\\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01]))";
     public static final String VERSION_STRING_REGEX = "(\\d(\\.\\d)?(\\.\\d)?)";
+    public static final String URN_FORMAT = "urn:ssb:klass-api:classifications:%s:code:%s";
 
     public static boolean isYearMonthDay(String date){
         return date.matches(YEAR_MONTH_DAY_REGEX);
@@ -126,6 +127,6 @@ public class Utils {
     }
 
     public static String generateURN(String classification, String code) {
-        return String.format("urn:ssb:klass-api:classifications:%s:code:%s", classification, code);
+        return String.format(URN_FORMAT, classification, code);
     }
 }


### PR DESCRIPTION
In response to @runejo 's feedback on https://jira.ssb.no/browse/KF-358 I now check both LDS and KLASS returns OK when I ask for subsets and classifications respectively. It was suggested by @runejo that I only check their health endpoints, but I would rather check the specific API call that I rely on: It might be that LDS says it is ready, but fails to return ClassificationSubset resources for some reason that the readiness endpoint does not account for. Similarly, KLASS might think it's alive or ready, but not actually be able to return classifications as expected. In addition to this, I check that my own subsets endpoint returns 200 OK. This way I guarantee my own readiness at every step, instead of relying on black boxes of other services.