### PR TITLE
Azure Pipelines improvements: Unit testing, and test against LDS running inside azure pipelines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ This API mimics the [KLASS Classifications API](https://data.ssb.no/api/klass/v1
 - `GET /v1/subsets/{id}/versions/{version}` to retrieve a list of versions that start with {version}
 - Where it makes sense there are optional `includeDraft` and `includeFuture` boolean parameters. `includeDraft` includes versions of subsets that are not currently published. `includeFuture` includes versions of subsets that will only be valid from a future date.
 
+### Health
+at `GET /health/alive` you can check whether the service is running.
+at `GET /health/ready` you can cehck whether the service can reach LDS and KLASS, and that itself returns 200 OK when attempting to return all of the subsets.
+
 ### Misc
 In addition, we support getting the subset schema at "/v1/subsets?schema"
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,12 @@ This API mimics the [KLASS Classifications API](https://data.ssb.no/api/klass/v1
 - Where it makes sense there are optional `includeDraft` and `includeFuture` boolean parameters. `includeDraft` includes versions of subsets that are not currently published. `includeFuture` includes versions of subsets that will only be valid from a future date.
 
 ### Health
-at `GET /health/alive` you can check whether the service is running.
-at `GET /health/ready` you can cehck whether the service can reach LDS and KLASS, and that itself returns 200 OK when attempting to return all of the subsets.
+- at `GET /health/alive` you can check whether the service is running.
+- at `GET /health/ready` you can cehck whether the service can reach LDS and KLASS, and that itself returns 200 OK when attempting to return all of the subsets.
+
+### Metrics
+- at `GET /customMetrics` you can see how many subsets API calls have been made since deployment
+- at `GET /testCounter` you can see how many call to the Metrics api (including /testCounter) have been made since deployment
 
 ### Misc
 In addition, we support getting the subset schema at "/v1/subsets?schema"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ KLASS Subsets REST Service, implemented in Spring Boot.
 
 This API serves to store, search and maintain KLASS subsets ("uttrekk").
 
-As a database we use an instance of Lpinked Data Store (LDS documentation: https://github.com/statisticsnorway/linked-data-store-documentation/tree/master/docs Docker Hub: https://hub.docker.com/r/statisticsnorway/lds-server/tags) with a Postgres backend.
+As a database we use an instance of Linked Data Store (LDS documentation: https://github.com/statisticsnorway/linked-data-store-documentation/tree/master/docs Docker Hub: https://hub.docker.com/r/statisticsnorway/lds-server/tags) with a Postgres backend.
 
 This service replaced a Node.js prototype, which can be found at: https://github.com/statisticsnorway/klass-subsets-service
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,7 @@ jobs:
       - task: DockerCompose@0
         displayName: Container registry login
         inputs:
+          dockerComposeFile: dockerComposeCIBuild
           containerregistrytype: Container Registry
           dockerRegistryEndpoint: dockerHubOlved
       - task: DockerCompose@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,8 +38,8 @@ jobs:
           secureFile: 'schema.graphql'
       - task: DockerCompose@0
         env:
-          - SQL_INIT_PATH $(sqlInit.secureFilePath)
-          - SCHEMA_PATH $(schemaGraphQL.secureFilePath)
+          SQL_INIT_PATH: $(sqlInit.secureFilePath)
+          SCHEMA_PATH: $(schemaGraphQL.secureFilePath)
         displayName: 'Run integration test backend services'
         inputs:
           action: Run services

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,23 @@ jobs:
   - job: buildTestDockerBuildDockerPush
     displayName: 'Test/build app and Dockerimage'
     steps:
+      - task: DockerCompose@0
+        displayName: Container registry login
+        inputs:
+          containerregistrytype: Container Registry
+          dockerRegistryEndpoint: dockerHubOlved
+      - task: DockerCompose@0
+        displayName: 'Run integration test backend services'
+        inputs:
+          action: Run services
+          containerregistrytype: Container Registry
+          dockerRegistryEndpoint: dockerHubOlved
+          dockerComposeFile: docker-compose.ci.build.yml
+          projectName: $(Build.Repository.Name)
+          qualifyImageNames: true
+          buildImages: false
+          abortOnContainerExit: true
+          detached: true
       - task: Maven@3
         displayName: 'Maven install'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ jobs:
           detached: true
       - task: Maven@3
         env:
-          API_LDS: "http://localhost:9090/ns/ClassificationSubset"
+          API_LDS: "http://host.docker.internal:9090/ns/ClassificationSubset"
           API_KLASS: "https://data.ssb.no/api/klass/v1/classifications"
         displayName: 'Maven install'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
       - task: DockerCompose@0
         displayName: Container registry login
         inputs:
-          dockerComposeFile: 'docker-compose.ci.build.yml'
+          dockerComposeFile: $(dockerComposeCIBuild.secureFilePath)
           containerregistrytype: Container Registry
           dockerRegistryEndpoint: dockerHubOlved
       - task: DockerCompose@0
@@ -38,7 +38,7 @@ jobs:
           action: Run services
           containerregistrytype: Container Registry
           dockerRegistryEndpoint: dockerHubOlved
-          dockerComposeFile: 'docker-compose.ci.build.yml'
+          dockerComposeFile: $(dockerComposeCIBuild.secureFilePath)
           projectName: $(Build.Repository.Name)
           qualifyImageNames: true
           buildImages: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,6 +52,9 @@ jobs:
           abortOnContainerExit: true
           detached: true
       - task: Maven@3
+        env:
+          API_LDS: "http://localhost:9090/ns/ClassificationSubset"
+          API_KLASS: "https://data.ssb.no/api/klass/v1/classifications"
         displayName: 'Maven install'
         inputs:
           mavenPomFile: 'pom.xml'
@@ -62,7 +65,7 @@ jobs:
           publishJUnitResults: false
           testResultsFiles: '**/TEST-*.xml'
           goals: 'install'
-          options: '-DskipTests=true -Dmaven.javadoc.skip=true'
+          options: '-DskipTests=false -Dmaven.javadoc.skip=true'
       # Build Docker image
       - task: Docker@2
         displayName: 'Docker build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,9 @@ jobs:
           buildImages: false
           abortOnContainerExit: true
           detached: true
+      - task: ShellScript@2
+        inputs:
+          scriptPath: sethost.sh
       - task: Maven@3
         env:
           API_LDS: "http://localhost:9090/ns/ClassificationSubset"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - task: DownloadSecureFile@1
         name: dockerComposeCIBuild # use $(dockerComposeCIBuild.secureFilePath) to refer to it
-        displayName: 'Download docker-compose.ci.build.yaml'
+        displayName: 'Download docker-compose.ci.build.yml'
         inputs:
           secureFile: 'docker-compose.ci.build.yml'
       - task: DownloadSecureFile@1
@@ -37,6 +37,9 @@ jobs:
         inputs:
           secureFile: 'schema.graphql'
       - task: DockerCompose@0
+        env:
+          - SQL_INIT_PATH $(sqlInit.secureFilePath)
+          - SCHEMA_PATH $(schemaGraphQL.secureFilePath)
         displayName: 'Run integration test backend services'
         inputs:
           action: Run services

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,7 @@ jobs:
           detached: true
       - task: Maven@3
         env:
-          API_LDS: "http://host.docker.internal:9090/ns/ClassificationSubset"
+          API_LDS: "http://localhost:9090/ns/ClassificationSubset"
           API_KLASS: "https://data.ssb.no/api/klass/v1/classifications"
         displayName: 'Maven install'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,10 +22,20 @@ jobs:
     displayName: 'Test/build app and Dockerimage'
     steps:
       - task: DownloadSecureFile@1
-        name: dockerComposeCIBuild
+        name: dockerComposeCIBuild # use $(dockerComposeCIBuild.secureFilePath) to refer to it
         displayName: 'Download docker-compose.ci.build.yaml'
         inputs:
           secureFile: 'docker-compose.ci.build.yml'
+      - task: DownloadSecureFile@1
+        name: sqlInit # use $(sqlInit.secureFilePath) to refer to it
+        displayName: 'Download init-db-and-user.sql'
+        inputs:
+          secureFile: 'init-db-and-user.sql'
+      - task: DownloadSecureFile@1
+        name: schemaGraphQL # use $(schemaGraphQL.secureFilePath) to refer to it
+        displayName: 'Download schema.graphql'
+        inputs:
+          secureFile: 'schema.graphql'
       - task: DockerCompose@0
         displayName: 'Run integration test backend services'
         inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,11 @@ jobs:
   - job: buildTestDockerBuildDockerPush
     displayName: 'Test/build app and Dockerimage'
     steps:
+      - task: DownloadSecureFile@1
+        name: dockerComposeCIBuild
+        displayName: 'Download docker-compose.ci.build.yaml'
+        inputs:
+          secureFile: 'docker-compose.ci.build.yml'
       - task: DockerCompose@0
         displayName: Container registry login
         inputs:
@@ -32,7 +37,7 @@ jobs:
           action: Run services
           containerregistrytype: Container Registry
           dockerRegistryEndpoint: dockerHubOlved
-          dockerComposeFile: docker-compose.ci.build.yml
+          dockerComposeFile: dockerComposeCIBuild
           projectName: $(Build.Repository.Name)
           qualifyImageNames: true
           buildImages: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
       - task: DockerCompose@0
         displayName: Container registry login
         inputs:
-          dockerComposeFile: dockerComposeCIBuild
+          dockerComposeFile: 'docker-compose.ci.build.yml'
           containerregistrytype: Container Registry
           dockerRegistryEndpoint: dockerHubOlved
       - task: DockerCompose@0
@@ -38,7 +38,7 @@ jobs:
           action: Run services
           containerregistrytype: Container Registry
           dockerRegistryEndpoint: dockerHubOlved
-          dockerComposeFile: dockerComposeCIBuild
+          dockerComposeFile: 'docker-compose.ci.build.yml'
           projectName: $(Build.Repository.Name)
           qualifyImageNames: true
           buildImages: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,12 +27,6 @@ jobs:
         inputs:
           secureFile: 'docker-compose.ci.build.yml'
       - task: DockerCompose@0
-        displayName: Container registry login
-        inputs:
-          dockerComposeFile: $(dockerComposeCIBuild.secureFilePath)
-          containerregistrytype: Container Registry
-          dockerRegistryEndpoint: dockerHubOlved
-      - task: DockerCompose@0
         displayName: 'Run integration test backend services'
         inputs:
           action: Run services

--- a/sethost.sh
+++ b/sethost.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 sleep 10
+docker ps
 host=localhost
 if grep '^1:name=systemd:/docker/' /proc/1/cgroup
 then

--- a/sethost.sh
+++ b/sethost.sh
@@ -2,14 +2,11 @@
 
 sleep 10
 
-echo "docker ps: "
-docker ps
+echo "docker ps -a: "
+docker ps -a
 
-echo "lds logs: "
-docker-compose -f docker-compose.ci.build.yml logs lds
-
-echo "postgresdb logs: "
-docker-compose -f docker-compose.ci.build.yml logs postgresdb
+echo "docker logs lds: "
+docker logs klass-subsets-setup-scratch_lds_1
 
 host=localhost
 if grep '^1:name=systemd:/docker/' /proc/1/cgroup

--- a/sethost.sh
+++ b/sethost.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
-sleep 10
-
 echo "docker ps -a: "
 docker ps -a
 
-echo "docker logs lds: "
-docker logs klass-subsets-setup-scratch_lds_1
+echo "*** docker logs lds: ***"
+docker logs statisticsnorwayklass-subsets-api_lds_1
+
+echo "*** docker logs postgres db: ***"
+docker logs statisticsnorwayklass-subsets-api_postgresdb_1
 
 host=localhost
 if grep '^1:name=systemd:/docker/' /proc/1/cgroup

--- a/sethost.sh
+++ b/sethost.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+host=localhost
+if grep '^1:name=systemd:/docker/' /proc/1/cgroup
+then
+    apt-get update
+    apt-get install net-tools
+    host=$(route -n | grep '^0.0.0.0' | sed -e 's/^0.0.0.0\s*//' -e 's/ .*//')
+fi
+export HOST_ADDRESS=$host
+echo "\$HOST_ADDRESS is $HOST_ADDRESS"

--- a/sethost.sh
+++ b/sethost.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+sleep 10
 host=localhost
 if grep '^1:name=systemd:/docker/' /proc/1/cgroup
 then

--- a/sethost.sh
+++ b/sethost.sh
@@ -1,7 +1,16 @@
 #!/usr/bin/env bash
 
 sleep 10
+
+echo "docker ps: "
 docker ps
+
+echo "lds logs: "
+docker-compose -f docker-compose.ci.build.yml logs lds
+
+echo "postgresdb logs: "
+docker-compose -f docker-compose.ci.build.yml logs postgresdb
+
 host=localhost
 if grep '^1:name=systemd:/docker/' /proc/1/cgroup
 then

--- a/src/main/java/no/ssb/subsetsservice/HealthController.java
+++ b/src/main/java/no/ssb/subsetsservice/HealthController.java
@@ -1,6 +1,5 @@
 package no.ssb.subsetsservice;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -17,7 +16,7 @@ public class HealthController {
     @RequestMapping("/health/ready")
     public ResponseEntity<String> ready() {
         boolean klassReady = new KlassURNResolver().pingKLASSClassifications();
-        boolean ldsReady = new LDSFacade().pingLDSSubsets();
+        boolean ldsReady = new LDSFacade().healthReady();
         boolean schemaPresent = new LDSFacade().getClassificationSubsetSchema().getStatusCode().equals(HttpStatus.OK);
         if (klassReady && ldsReady && schemaPresent)
             return new ResponseEntity<>("The service is ready!", HttpStatus.OK);

--- a/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
+++ b/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
@@ -12,9 +12,8 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.ArrayList;
+
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class KlassURNResolver {

--- a/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
@@ -13,11 +13,12 @@ import java.util.Collections;
 public class LDSConsumer {
 
     private static final Logger LOG = LoggerFactory.getLogger(LDSConsumer.class);
-    static String LDS_LOCAL = "http://localhost:9090/ns/ClassificationSubset";
+    static String LDS_LOCAL = "http://host.docker.internal:9090/ns/ClassificationSubset";
     static String LDS_URL;
 
     LDSConsumer(){
         LDS_URL = getURLFromEnvOrDefault();
+        LOG.debug("LDS URL: "+LDS_URL);
     }
 
 
@@ -25,6 +26,7 @@ public class LDSConsumer {
         LDS_URL = API_LDS;
         if (LDS_URL.equals(""))
             LDS_URL = getURLFromEnvOrDefault();
+        LOG.debug("LDS URL: "+LDS_URL);
     }
 
     private static String getURLFromEnvOrDefault(){

--- a/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
@@ -30,6 +30,8 @@ public class LDSConsumer {
     }
 
     private static String getURLFromEnvOrDefault(){
+        String host = System.getenv().getOrDefault("HOST_ADDRESS", "localhost");
+        LDS_LOCAL = "http://"+host+"/ns/ClassificationSubset";
         return System.getenv().getOrDefault("API_LDS", LDS_LOCAL);
     }
 

--- a/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 public class LDSConsumer {
 
     private static final Logger LOG = LoggerFactory.getLogger(LDSConsumer.class);
-    static String LDS_LOCAL = "http://host.docker.internal:9090/ns/ClassificationSubset";
+    static String LDS_LOCAL = "http://localhost:9090/ns/ClassificationSubset";
     static String LDS_URL;
 
     LDSConsumer(){

--- a/src/main/java/no/ssb/subsetsservice/LDSFacade.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSFacade.java
@@ -64,7 +64,7 @@ public class LDSFacade implements LDSInterface {
     }
 
     @Override
-    public boolean pingLDSSubsets() {
+    public boolean healthReady() {
         return new LDSConsumer("https://lds-klass.staging-bip-app.ssb.no/health/ready").getFrom("").getStatusCode().equals(HttpStatus.OK);
     }
 }

--- a/src/main/java/no/ssb/subsetsservice/LDSInterface.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSInterface.java
@@ -64,5 +64,5 @@ public interface LDSInterface {
      */
     ResponseEntity<JsonNode> createSubset(JsonNode subset, String id);
 
-    boolean pingLDSSubsets();
+    boolean healthReady();
 }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -27,6 +27,10 @@ public class SubsetsController {
         instance = this;
     }
 
+    public SubsetsController(){
+        instance = this;
+    }
+
     public static SubsetsController getInstance(){
         return instance;
     }

--- a/src/test/java/no/ssb/subsetsservice/KlassURNResolverTest.java
+++ b/src/test/java/no/ssb/subsetsservice/KlassURNResolverTest.java
@@ -1,0 +1,14 @@
+package no.ssb.subsetsservice;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class KlassURNResolverTest {
+
+    @Test
+    void pingKLASSClassifications() {
+        boolean ping = new KlassURNResolver().pingKLASSClassifications();
+        assertTrue(ping);
+    }
+}

--- a/src/test/java/no/ssb/subsetsservice/LDSFacadeTest.java
+++ b/src/test/java/no/ssb/subsetsservice/LDSFacadeTest.java
@@ -3,6 +3,7 @@ package no.ssb.subsetsservice;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.ResourceAccessException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -10,15 +11,29 @@ class LDSFacadeTest {
 
     @Test
     void existsLdsApiEnv(){
-        System.out.println("ENV variable API_LDS "+System.getenv().getOrDefault("API_LDS", "was not present"));
+        System.out.println("ENV variable API_LDS " + System.getenv().getOrDefault("API_LDS", "was not present"));
     }
 
     @Test
     void getLastUpdatedVersionOfAllSubsets() {
-        ResponseEntity<JsonNode> allSubsets = new LDSFacade().getLastUpdatedVersionOfAllSubsets();
-        assertTrue(allSubsets.hasBody());
-        if (allSubsets.hasBody())
-            assertTrue(allSubsets.getBody().isArray());
+        try {
+            ResponseEntity<JsonNode> allSubsets = new LDSFacade().getLastUpdatedVersionOfAllSubsets();
+            assertTrue(allSubsets.hasBody());
+            if (allSubsets.hasBody())
+                assertTrue(allSubsets.getBody().isArray());
+        } catch (ResourceAccessException e){
+            System.err.println("Message: "+e.getMessage());
+            System.err.println("Localized Message: "+e.getLocalizedMessage());
+            System.err.println("Cause: "+e.getCause().toString());
+            System.err.println("Most specific cause: "+e.getMostSpecificCause().toString());
+            System.err.println("Root cause "+e.getRootCause().toString());
+        } catch (Error e){
+            e.printStackTrace();
+            System.err.println("Message: "+e.getMessage());
+            System.err.println("Localized Message: "+e.getLocalizedMessage());
+            System.err.println("Cause: "+e.getCause().toString());
+        }
+
     }
 
     @Test

--- a/src/test/java/no/ssb/subsetsservice/LDSFacadeTest.java
+++ b/src/test/java/no/ssb/subsetsservice/LDSFacadeTest.java
@@ -9,6 +9,11 @@ import static org.junit.jupiter.api.Assertions.*;
 class LDSFacadeTest {
 
     @Test
+    void existsLdsApiEnv(){
+        System.out.println("ENV variable API_LDS "+System.getenv().getOrDefault("API_LDS", "was not present"));
+    }
+
+    @Test
     void getLastUpdatedVersionOfAllSubsets() {
         ResponseEntity<JsonNode> allSubsets = new LDSFacade().getLastUpdatedVersionOfAllSubsets();
         assertTrue(allSubsets.hasBody());

--- a/src/test/java/no/ssb/subsetsservice/LDSFacadeTest.java
+++ b/src/test/java/no/ssb/subsetsservice/LDSFacadeTest.java
@@ -1,0 +1,24 @@
+package no.ssb.subsetsservice;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LDSFacadeTest {
+
+    @Test
+    void getLastUpdatedVersionOfAllSubsets() {
+        ResponseEntity<JsonNode> allSubsets = new LDSFacade().getLastUpdatedVersionOfAllSubsets();
+        assertTrue(allSubsets.hasBody());
+        if (allSubsets.hasBody())
+            assertTrue(allSubsets.getBody().isArray());
+    }
+
+    @Test
+    void healthReady() {
+        boolean ready = new LDSFacade().healthReady();
+        assertTrue(ready);
+    }
+}

--- a/src/test/java/no/ssb/subsetsservice/SubsetsControllerTest.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsControllerTest.java
@@ -1,23 +1,31 @@
 package no.ssb.subsetsservice;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import org.junit.Before;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 import static no.ssb.subsetsservice.LDSConsumer.LDS_LOCAL;
 import static org.junit.jupiter.api.Assertions.*;
 
+@SpringBootTest
 class SubsetsControllerTest {
 
-    LDSFacade ldsFacade;
-
-    @Before
-    public void setup(){
-        String ldsURL = System.getenv().getOrDefault("TEST_LDS_URL", LDS_LOCAL);
-        ldsFacade = new LDSFacade(ldsURL);
+    @Test
+    void getSubsetsUrnOnly() {
+        SubsetsController instance = SubsetsController.getInstance();
+        assertNotNull(instance);
+        ResponseEntity<JsonNode> subsets = instance.getSubsets(true, true, true);
+        assertEquals(HttpStatus.OK, subsets.getStatusCode());
     }
 
     @Test
     void getSubsets() {
-
+        SubsetsController instance = SubsetsController.getInstance();
+        assertNotNull(instance);
+        ResponseEntity<JsonNode> subsets = instance.getSubsets(true, true, false);
+        assertEquals(HttpStatus.OK, subsets.getStatusCode());
     }
 }

--- a/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
@@ -8,8 +8,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.ResponseEntity;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 class SubsetsServiceApplicationTests {
@@ -35,7 +34,7 @@ class SubsetsServiceApplicationTests {
 		System.out.println("RESPONSE BODY");
 		System.out.println(response.getBody());
 		assertNotEquals(null, response.getBody());
-		assertNotEquals("[]", response.getBody());
+		assertNotEquals("[]", response.getBody().asText());
 	}
 
 	@Test
@@ -85,7 +84,8 @@ class SubsetsServiceApplicationTests {
 		System.out.println(response.getBody());
 		System.out.println("IDs:");
 		for (JsonNode jsonNode : response.getBody()) {
-			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText(), false, false, false).getBody();
+			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText(), true, true, false).getBody();
+			assertTrue(subset.has("id"));
 			assertEquals(subset.get("id").asText(), jsonNode.get("id").asText());
 			System.out.println(subset.get("id"));
 		}
@@ -96,20 +96,23 @@ class SubsetsServiceApplicationTests {
 		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubsets( true, true, false);
 
 		System.out.println("All subsets:");
-		System.out.println(response.getBody());
+		JsonNode body = response.getBody();
+		assertNotNull(body);
+		System.out.println(body);
 		System.out.println("IDs:");
 		for (JsonNode jsonNode : response.getBody()) {
-			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText(), false, false, false).getBody();
+			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText(), true, true, false).getBody();
+			assertNotNull(subset);
+			assertTrue(subset.has("id"));
 			assertEquals(subset.get("id").asText(), jsonNode.get("id").asText());
 			System.out.println("ID: "+subset.get("id"));
 
 			ArrayNode versions = (ArrayNode) SubsetsController.getInstance().getVersions(subset.get("id").asText(), true, true, false).getBody();
-			assertNotEquals(null, versions);
+			assertNotNull(versions);
 			assertNotEquals(0, versions.size());
 			for (JsonNode version : versions) {
 				System.out.println("Version: "+version.get("version").asText()+" adminstatus: "+version.get("administrativeStatus").asText()+" name:"+version.get("name").get(0).get("languageText").asText());
 			}
-
 		}
 	}
 


### PR DESCRIPTION
The Maven build task now runs the JUnit tests. 

Some of the JUnit tests fire operations against an LDS instance fully configured with a Postgres backend. The LDS/Pg stack is running as a docker-compose task inside the Azure Pipeline.

To run LDS and Postgres services from docker-compose, we:
- Load graphql and sql files from AP Secure Files (accessible from the Library of the pipeline), and store their paths on the AP agent as ENV variables
- Start services from a docker-compose file very similar to `klass-subsets-setup`, pointing to the laoded graphql and sql files as volumes to be used by LDS and Postgres.  This `docker-compose.ci.build.yml` is also a Secure File located in the Library.

To see the docker images, docker-compose YAML and more, go to [this pull request.](https://github.com/statisticsnorway/klass-subsets-setup/pull/6)

Pull request #87 needs to be accepted/merged before this is merged, because this uses elements from that.