### PR TITLE
clients can ask for urnOnly. Then we don't resolve URNs against KLASS

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/HealthController.java
+++ b/src/main/java/no/ssb/subsetsservice/HealthController.java
@@ -16,7 +16,7 @@ public class HealthController {
 
     @RequestMapping("/health/ready")
     public ResponseEntity<String> ready() {
-        ResponseEntity<JsonNode> responseEntity = SubsetsController.getInstance().getSubsets(false, false);
+        ResponseEntity<JsonNode> responseEntity = SubsetsController.getInstance().getSubsets(false, false, true);
         if (responseEntity.getStatusCodeValue() == 200)
             return new ResponseEntity<>("The service is ready!", HttpStatus.OK);
         return new ResponseEntity<>("The service is not ready yet.", HttpStatus.SERVICE_UNAVAILABLE);

--- a/src/main/java/no/ssb/subsetsservice/HealthController.java
+++ b/src/main/java/no/ssb/subsetsservice/HealthController.java
@@ -16,11 +16,9 @@ public class HealthController {
 
     @RequestMapping("/health/ready")
     public ResponseEntity<String> ready() {
-        boolean klassReady = new KlassURNResolver().pingKLASSClassifications();
-        boolean ldsReady = new LDSFacade().pingLDSSubsets();
-        boolean schemaPresent = new LDSFacade().getClassificationSubsetSchema().getStatusCode().equals(HttpStatus.OK);
-        if (klassReady && ldsReady && schemaPresent)
+        ResponseEntity<JsonNode> responseEntity = SubsetsController.getInstance().getSubsets(false, false, true);
+        if (responseEntity.getStatusCodeValue() == 200)
             return new ResponseEntity<>("The service is ready!", HttpStatus.OK);
-        return new ResponseEntity<>("The service is not ready yet.\n KLASS ready: "+klassReady+" \n", HttpStatus.SERVICE_UNAVAILABLE);
+        return new ResponseEntity<>("The service is not ready yet.", HttpStatus.SERVICE_UNAVAILABLE);
     }
 }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -32,7 +32,7 @@ public class SubsetsController {
     }
 
     @GetMapping("/v1/subsets")
-    public ResponseEntity<JsonNode> getSubsets( @RequestParam(defaultValue = "false") boolean includeDrafts, @RequestParam(defaultValue = "false") boolean includeFuture) {
+    public ResponseEntity<JsonNode> getSubsets( @RequestParam(defaultValue = "false") boolean includeDrafts, @RequestParam(defaultValue = "false") boolean includeFuture, @RequestParam(defaultValue = "false") boolean urnOnly) {
         metricsService.incrementGETCounter();
 
         LOG.info("GET subsets");
@@ -40,7 +40,7 @@ public class SubsetsController {
         List<String> subsetIDsList = ldsFacade.getAllSubsetIDs();
         ArrayNode arrayNode = new ObjectMapper().createArrayNode();
         for (String id : subsetIDsList) {
-            ResponseEntity<JsonNode> subsetRE = getSubset(id, includeDrafts, includeFuture);
+            ResponseEntity<JsonNode> subsetRE = getSubset(id, includeDrafts, includeFuture, urnOnly);
             if (subsetRE.getStatusCode() == HttpStatus.OK)
                 arrayNode.add(subsetRE.getBody());
             else
@@ -86,18 +86,19 @@ public class SubsetsController {
     }
 
     @GetMapping("/v1/subsets/{id}")
-    public ResponseEntity<JsonNode> getSubset(@PathVariable("id") String id, @RequestParam(defaultValue = "false") boolean includeDrafts, @RequestParam(defaultValue = "false") boolean includeFuture) {
+    public ResponseEntity<JsonNode> getSubset(@PathVariable("id") String id, @RequestParam(defaultValue = "false") boolean includeDrafts, @RequestParam(defaultValue = "false") boolean includeFuture, @RequestParam(defaultValue = "false") boolean urnOnly) {
         metricsService.incrementGETCounter();
-        LOG.info("GET subset with id "+id);
+        LOG.info("GET subset with id "+id+" includeDrafts");
 
         if (Utils.isClean(id)){
-            ResponseEntity<JsonNode> majorVersionsRE = getVersions(id, includeFuture, includeDrafts);
+            ResponseEntity<JsonNode> majorVersionsRE = getVersions(id, includeFuture, includeDrafts, urnOnly);
             if (majorVersionsRE.getStatusCode() != HttpStatus.OK) {
                 LOG.error("Failed to get version of subset "+id);
                 return majorVersionsRE;
             }
             JsonNode majorVersionsBody = majorVersionsRE.getBody();
             if (majorVersionsBody != null && majorVersionsBody.isArray()){
+                LOG.debug("The array node with major versions");
                 if (majorVersionsBody.has(0))
                     return new ResponseEntity<>(majorVersionsBody.get(0), HttpStatus.OK);
                 return ErrorHandler.newHttpError("No subset matched the parameters", HttpStatus.NOT_FOUND, LOG);
@@ -116,8 +117,8 @@ public class SubsetsController {
         if (Utils.isClean(id)) {
             ObjectNode editableSubset = Utils.cleanSubsetVersion(newVersionOfSubset).deepCopy();
             editableSubset.put(Field.LAST_UPDATED_DATE, Utils.getNowISO());
-            ResponseEntity<JsonNode> mostRecentVersionRE = getSubset(id, true, true);
-            ResponseEntity<JsonNode> oldVersionsRE = getVersions(id, true, true);
+            ResponseEntity<JsonNode> mostRecentVersionRE = getSubset(id, true, true, true);
+            ResponseEntity<JsonNode> oldVersionsRE = getVersions(id, true, true, true);
             JsonNode mostRecentVersionOfThisSubset = mostRecentVersionRE.getBody();
             if (mostRecentVersionRE.getStatusCodeValue() == HttpStatus.OK.value()){
                 assert mostRecentVersionOfThisSubset != null && mostRecentVersionOfThisSubset.has(Field.ID) : "no old subset with this id was found in body of response entity";
@@ -153,7 +154,7 @@ public class SubsetsController {
                     }
                 }
 
-                ResponseEntity<JsonNode> prevPatchOfThisVersionRE = getVersion(id, newVersionString);
+                ResponseEntity<JsonNode> prevPatchOfThisVersionRE = getVersion(id, newVersionString, false);
                 boolean thisVersionExistsFromBefore = prevPatchOfThisVersionRE.getStatusCodeValue() == 200;
                 boolean attemptToChangeCodesOfPublishedVersion = false;
                 if (thisVersionExistsFromBefore){
@@ -228,7 +229,7 @@ public class SubsetsController {
     }
 
     @GetMapping("/v1/subsets/{id}/versions")
-    public ResponseEntity<JsonNode> getVersions(@PathVariable("id") String id, @RequestParam(defaultValue = "false") boolean includeFuture, @RequestParam(defaultValue = "false") boolean includeDrafts) {
+    public ResponseEntity<JsonNode> getVersions(@PathVariable("id") String id, @RequestParam(defaultValue = "false") boolean includeFuture, @RequestParam(defaultValue = "false") boolean includeDrafts, @RequestParam(defaultValue = "false") boolean urnOnly) {
         metricsService.incrementGETCounter();
         LOG.info("GET all versions of subset with id: "+id+" includeFuture: "+includeFuture+" includeDrafts: "+includeDrafts);
 
@@ -280,19 +281,13 @@ public class SubsetsController {
                     LOG.debug("versionLastUpdatedMap size: "+versionLastUpdatedMap.size());
 
                     ArrayList<JsonNode> versionList = new ArrayList<>(versionLastUpdatedMap.size());
-                    versionLastUpdatedMap.forEach((versionInt, versionJsonNode) -> versionList.add(versionJsonNode));
+                    for (Map.Entry<Integer, JsonNode> entry : versionLastUpdatedMap.entrySet()) {
+                        versionList.add(entry.getValue());
+                    }
                     LOG.debug("versionList size: "+versionList.size());
                     versionList.sort(Utils::versionComparator);
-                    String validTo = ""; //FIXME: This means the most recent version does not have a validTo. Is it potentially a mistake?
-                    for (int i = 0; i < versionList.size(); i++) {
-                        ObjectNode editableSubset = versionList.get(i).deepCopy();
-                        ArrayNode resolvedCodes = resolveURNs(editableSubset, validTo);
-                        editableSubset.set(Field.CODES, resolvedCodes);
-                        validTo = editableSubset.get(Field.VERSION_VALID_FROM).asText();
-                        versionList.set(i, editableSubset.deepCopy());
-                    }
-                    LOG.debug("URNs are resolved");
-
+                    if (!urnOnly)
+                        versionList = resolveURNsOfCodesInAllVersions(versionList);
                     ArrayNode majorVersionsArrayNode = mapper.createArrayNode();
                     versionList.forEach(majorVersionsArrayNode::add);
                     LOG.debug("majorVersionsArrayNode size: "+majorVersionsArrayNode.size());
@@ -350,13 +345,13 @@ public class SubsetsController {
      * @return
      */
     @GetMapping("/v1/subsets/{id}/versions/{version}")
-    public ResponseEntity<JsonNode> getVersion(@PathVariable("id") String id, @PathVariable("version") String version) {
+    public ResponseEntity<JsonNode> getVersion(@PathVariable("id") String id, @PathVariable("version") String version, @RequestParam(defaultValue = "false") boolean urnOnly) {
         metricsService.incrementGETCounter();
         LOG.info("GET version "+version+" of subset with id "+id);
 
         if (Utils.isClean(id) && Utils.isVersion(version)){
             if (Utils.isVersion(version)){
-                ResponseEntity<JsonNode> versionsRE = getVersions(id, true, true);
+                ResponseEntity<JsonNode> versionsRE = getVersions(id, true, true, urnOnly);
                 JsonNode responseBodyJSON = versionsRE.getBody();
                 if (responseBodyJSON != null){
                     if (responseBodyJSON.isArray()) {
@@ -387,14 +382,20 @@ public class SubsetsController {
      * @return
      */
     @GetMapping("/v1/subsets/{id}/codes")
-    public ResponseEntity<JsonNode> getSubsetCodes(@PathVariable("id") String id, @RequestParam(required = false) String from, @RequestParam(required = false) String to, @RequestParam(defaultValue = "false") boolean includeDrafts, @RequestParam(defaultValue = "false") boolean includeFuture) {
+    public ResponseEntity<JsonNode> getSubsetCodes(@PathVariable("id") String id,
+                                                   @RequestParam(required = false) String from,
+                                                   @RequestParam(required = false) String to,
+                                                   @RequestParam(defaultValue = "false") boolean includeDrafts,
+                                                   @RequestParam(defaultValue = "false") boolean includeFuture,
+                                                   @RequestParam(defaultValue = "false") boolean urnOnly) {
+
         LOG.info("GET codes of subset with id "+id);
         metricsService.incrementGETCounter();
 
         if (Utils.isClean(id)){
             if (from == null && to == null){
                 LOG.debug("getting all codes of the latest/current version of subset "+id);
-                ResponseEntity<JsonNode> subsetResponseEntity = getSubset(id, includeDrafts, includeFuture);
+                ResponseEntity<JsonNode> subsetResponseEntity = getSubset(id, includeDrafts, includeFuture, urnOnly);
                 JsonNode responseBodyJSON = subsetResponseEntity.getBody();
                 if (responseBodyJSON != null){
                     ArrayNode codes = (ArrayNode) responseBodyJSON.get(Field.CODES);
@@ -412,7 +413,7 @@ public class SubsetsController {
             boolean isToDate = to != null;
             if ((!isFromDate || Utils.isYearMonthDay(from)) && (!isToDate || Utils.isYearMonthDay(to))){ // If a date is given as param, it must be valid format
                 // If a date interval is specified using 'from' and 'to' query parameters
-                ResponseEntity<JsonNode> versionsResponseEntity = getVersions(id, includeFuture, includeDrafts);
+                ResponseEntity<JsonNode> versionsResponseEntity = getVersions(id, includeFuture, includeDrafts, urnOnly);
                 JsonNode responseBodyJSON = versionsResponseEntity.getBody();
                 LOG.debug(String.format("Getting valid codes of subset %s from date %s to date %s", id, from, to));
                 ObjectMapper mapper = new ObjectMapper();
@@ -499,12 +500,16 @@ public class SubsetsController {
      * @return
      */
     @GetMapping("/v1/subsets/{id}/codesAt")
-    public ResponseEntity<JsonNode> getSubsetCodesAt(@PathVariable("id") String id, @RequestParam String date, @RequestParam(defaultValue = "false") boolean includeFuture, @RequestParam(defaultValue = "false") boolean includeDrafts) {
+    public ResponseEntity<JsonNode> getSubsetCodesAt(@PathVariable("id") String id,
+                                                     @RequestParam String date,
+                                                     @RequestParam(defaultValue = "false") boolean includeFuture,
+                                                     @RequestParam(defaultValue = "false") boolean includeDrafts,
+                                                     @RequestParam(defaultValue = "false") boolean urnOnly) {
         metricsService.incrementGETCounter();
         LOG.info("GET codes valid at date "+date+" for subset with id "+id);
 
         if (date != null && Utils.isClean(id) && (Utils.isYearMonthDay(date))){
-            ResponseEntity<JsonNode> versionsResponseEntity = getVersions(id, includeFuture, includeDrafts);
+            ResponseEntity<JsonNode> versionsResponseEntity = getVersions(id, includeFuture, includeDrafts, urnOnly);
             JsonNode responseBodyJSON = versionsResponseEntity.getBody();
             if (responseBodyJSON != null){
                 if (responseBodyJSON.isArray()) {
@@ -544,19 +549,35 @@ public class SubsetsController {
         return new LDSFacade().getClassificationSubsetSchema();
     }
 
-    private ArrayNode resolveURNs(JsonNode subset, String to){
-        to = to.split("T")[0];
-        if (to.equals("") || Utils.isYearMonthDay(to)){
+    private ArrayList<JsonNode> resolveURNsOfCodesInAllVersions(ArrayList<JsonNode> versionListInput){
+        ArrayList<JsonNode> versionList = new ArrayList<>(versionListInput.size());
+        versionListInput.forEach(v -> versionList.add(v.deepCopy()));
+        versionList.sort(Utils::versionComparator);
+
+        String validTo = ""; //FIXME: This means the most recent version does not have a validTo. Is it potentially a mistake?
+        for (int i = 0; i < versionList.size(); i++) {
+            ObjectNode editableSubset = versionList.get(i).deepCopy();
+            ArrayNode resolvedCodes = resolveURNsOfCodesInThisSubset(editableSubset, validTo);
+            editableSubset.set(Field.CODES, resolvedCodes);
+            validTo = editableSubset.get(Field.VERSION_VALID_FROM).asText();
+            versionList.set(i, editableSubset.deepCopy());
+        }
+        LOG.debug("URNs of all versions are resolved");
+        return versionList;
+    }
+
+    private ArrayNode resolveURNsOfCodesInThisSubset(JsonNode subset, String subsetValidTo){
+        subsetValidTo = subsetValidTo.split("T")[0];
+        if (subsetValidTo.equals("") || Utils.isYearMonthDay(subsetValidTo)){
             try {
-                ArrayNode codeURNArrayNode = new KlassURNResolver().resolveURNs(subset, to);
-                System.out.println(codeURNArrayNode.toPrettyString());
+                ArrayNode codeURNArrayNode = new KlassURNResolver().resolveURNs(subset, subsetValidTo);
                 return codeURNArrayNode;
             } catch (Exception | Error e){
                 LOG.error(e.toString());
                 return (ArrayNode)subset.get(Field.CODES);
             }
         }
-        throw new IllegalArgumentException("'to' must be empty string '' or on the form YYYY-MM-DD, but was "+to);
+        throw new IllegalArgumentException("'to' must be empty string '' or on the form YYYY-MM-DD, but was "+subsetValidTo);
     }
 
 }

--- a/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
@@ -27,7 +27,7 @@ class SubsetsServiceApplicationTests {
 
 	@Test
 	void getAllSubsets() {
-		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubsets(true, true);
+		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubsets(true, true, false);
 
 		assertEquals(200, response.getStatusCodeValue());
 		System.out.println("RESPONSE HEADERS:");
@@ -40,7 +40,7 @@ class SubsetsServiceApplicationTests {
 
 	@Test
 	void getIllegalIdSubset() {
-		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubset("this-id-is-not-legal-¤%&#!§|`^¨~'*=)(/\\£$@{[]}", false, false);
+		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubset("this-id-is-not-legal-¤%&#!§|`^¨~'*=)(/\\£$@{[]}", false, false, false);
 
 		System.out.println("STATUS CODE");
 		System.out.println(response.getStatusCodeValue());
@@ -53,7 +53,7 @@ class SubsetsServiceApplicationTests {
 
 	@Test
 	void getNonExistingSubset() {
-		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubset("this-id-does-not-exist", false, false);
+		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubset("this-id-does-not-exist", false, false, false);
 
 		System.out.println("STATUS CODE");
 		System.out.println(response.getStatusCodeValue());
@@ -66,7 +66,7 @@ class SubsetsServiceApplicationTests {
 
 	@Test
 	void getNonExistantSubsetVersions() {
-		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getVersions("this-id-does-not-exist", true, true);
+		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getVersions("this-id-does-not-exist", true, true, false);
 
 		System.out.println("STATUS CODE");
 		System.out.println(response.getStatusCodeValue());
@@ -79,13 +79,13 @@ class SubsetsServiceApplicationTests {
 
 	@Test
 	void getAllIndividualSubsetsCompareIDs() {
-		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubsets(true, true);
+		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubsets(true, true, false);
 
 		System.out.println("All subsets:");
 		System.out.println(response.getBody());
 		System.out.println("IDs:");
 		for (JsonNode jsonNode : response.getBody()) {
-			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText(), false, false).getBody();
+			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText(), false, false, false).getBody();
 			assertEquals(subset.get("id").asText(), jsonNode.get("id").asText());
 			System.out.println(subset.get("id"));
 		}
@@ -93,17 +93,17 @@ class SubsetsServiceApplicationTests {
 
 	@Test
 	void getAllVersionsOfAllSubsets() {
-		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubsets( true, true);
+		ResponseEntity<JsonNode> response = SubsetsController.getInstance().getSubsets( true, true, false);
 
 		System.out.println("All subsets:");
 		System.out.println(response.getBody());
 		System.out.println("IDs:");
 		for (JsonNode jsonNode : response.getBody()) {
-			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText(), false, false).getBody();
+			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText(), false, false, false).getBody();
 			assertEquals(subset.get("id").asText(), jsonNode.get("id").asText());
 			System.out.println("ID: "+subset.get("id"));
 
-			ArrayNode versions = (ArrayNode) SubsetsController.getInstance().getVersions(subset.get("id").asText(), true, true).getBody();
+			ArrayNode versions = (ArrayNode) SubsetsController.getInstance().getVersions(subset.get("id").asText(), true, true, false).getBody();
 			assertNotEquals(null, versions);
 			assertNotEquals(0, versions.size());
 			for (JsonNode version : versions) {


### PR DESCRIPTION
All relevant API calls now have a `urnOnly` request parameter that defaults to `false`. When it is set to `true`, the Codes do not get supplemented with the code information from KLASS: Only what is stored about the codes in LDS is returned. Often this includes URN, rank, and href for each code. So it's not really "URN only". I think the rank and href information should also stay. If you have a better idea for a name for the parameter, come with a suggestion 👂 