### PR TITLE
use and expect true base URL for api

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,9 @@ jobs:
     displayName: 'Test/build app and Dockerimage'
     steps:
       - task: Maven@3
+        env:
+          API_LDS: "http://localhost:9090"
+          API_KLASS: "https://data.ssb.no/api/klass"
         displayName: 'Maven install'
         inputs:
           mavenPomFile: 'pom.xml'

--- a/src/main/java/no/ssb/subsetsservice/HealthController.java
+++ b/src/main/java/no/ssb/subsetsservice/HealthController.java
@@ -17,7 +17,7 @@ public class HealthController {
     @RequestMapping("/health/ready")
     public ResponseEntity<String> ready() {
         boolean klassReady = new KlassURNResolver().pingKLASSClassifications();
-        boolean ldsReady = new LDSFacade().pingLDSSubsets();
+        boolean ldsReady = new LDSFacade().healthReady();
         boolean schemaPresent = new LDSFacade().getClassificationSubsetSchema().getStatusCode().equals(HttpStatus.OK);
         if (klassReady && ldsReady && schemaPresent)
             return new ResponseEntity<>("The service is ready!", HttpStatus.OK);

--- a/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
+++ b/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
@@ -20,15 +20,16 @@ import java.util.Map;
 public class KlassURNResolver {
 
     private static final Logger LOG = LoggerFactory.getLogger(KlassURNResolver.class);
-    public static String klassBaseURL = "https://data.ssb.no/api/klass/v1/classifications";
+    public static String KLASS_BASE_URL = "https://data.ssb.no/api/klass";
+    public static final String CLASSIFICATIONS_API = "/v1/classifications";
 
     public boolean pingKLASSClassifications(){
-        ResponseEntity<String> re = getStringResponseFrom("https://data.ssb.no/api/klass/ping/");
+        ResponseEntity<String> re = getStringResponseFrom(String.format("%s/ping/", KLASS_BASE_URL));
         return re.getStatusCode().equals(HttpStatus.OK);
     }
 
     public static String getURL(){
-        return System.getenv().getOrDefault("API_KLASS", klassBaseURL);
+        return System.getenv().getOrDefault("API_KLASS", KLASS_BASE_URL);
     }
 
     /**
@@ -99,8 +100,8 @@ public class KlassURNResolver {
     }
 
     private String makeURL(String classificationID, String from, String to, String codes){
-        klassBaseURL = getURL();
-        return String.format("%s/%s/codes.json?from=%s&to=%s&selectCodes=%s", klassBaseURL, classificationID, from, to, codes);
+        KLASS_BASE_URL = getURL();
+        return String.format("%s%s/%s/codes.json?from=%s&to=%s&selectCodes=%s", KLASS_BASE_URL, CLASSIFICATIONS_API, classificationID, from, to, codes);
     }
 
     private ResponseEntity<JsonNode> getFrom(String url)

--- a/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
@@ -13,7 +13,7 @@ import java.util.Collections;
 public class LDSConsumer {
 
     private static final Logger LOG = LoggerFactory.getLogger(LDSConsumer.class);
-    static String LDS_LOCAL = "http://localhost:9090/ns/ClassificationSubset";
+    static String LDS_LOCAL = "http://localhost:9090";
     static String LDS_URL;
 
     LDSConsumer(){
@@ -28,6 +28,10 @@ public class LDSConsumer {
     }
 
     private static String getURLFromEnvOrDefault(){
+        String host = System.getenv().getOrDefault("HOST_ADDRESS", "localhost");
+        LOG.debug("Host: "+host);
+        LDS_LOCAL = "http://"+host+":9090";
+        LOG.debug("LDS_LOCAL: "+LDS_LOCAL);
         return System.getenv().getOrDefault("API_LDS", LDS_LOCAL);
     }
 

--- a/src/main/java/no/ssb/subsetsservice/LDSFacade.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSFacade.java
@@ -12,6 +12,7 @@ import java.util.List;
 public class LDSFacade implements LDSInterface {
 
     String API_LDS = "";
+    String SUBSETS_API = "/ns/ClassificationSubset";
 
     LDSFacade(){}
 
@@ -40,31 +41,31 @@ public class LDSFacade implements LDSInterface {
     }
 
     public ResponseEntity<JsonNode> getLastUpdatedVersionOfAllSubsets(){
-        return new LDSConsumer().getFrom("");
+        return new LDSConsumer().getFrom(SUBSETS_API+"");
     }
 
     public ResponseEntity<JsonNode> getTimelineOfSubset(String id){
-        return new LDSConsumer(API_LDS).getFrom("/"+id+"?timeline");
+        return new LDSConsumer(API_LDS).getFrom(SUBSETS_API+"/"+id+"?timeline");
     }
 
     public boolean existsSubsetWithID(String id){
-        return new LDSConsumer(API_LDS).getFrom("/"+id).getStatusCode().equals(HttpStatus.OK);
+        return new LDSConsumer(API_LDS).getFrom(SUBSETS_API+"/"+id).getStatusCode().equals(HttpStatus.OK);
     }
 
     public ResponseEntity<JsonNode> getClassificationSubsetSchema(){
-        return new LDSConsumer().getFrom("/?schema");
+        return new LDSConsumer().getFrom(SUBSETS_API+"/?schema");
     }
 
     public ResponseEntity<JsonNode> editSubset(JsonNode subset, String id){
-        return new LDSConsumer(API_LDS).putTo("/" + id, subset);
+        return new LDSConsumer(API_LDS).putTo(SUBSETS_API+"/" + id, subset);
     }
 
     public ResponseEntity<JsonNode> createSubset(JsonNode subset, String id){
-        return new LDSConsumer(API_LDS).postTo("/" + id, subset);
+        return new LDSConsumer(API_LDS).postTo(SUBSETS_API+"/" + id, subset);
     }
 
     @Override
-    public boolean pingLDSSubsets() {
-        return new LDSConsumer("https://lds-klass.staging-bip-app.ssb.no/health/ready").getFrom("").getStatusCode().equals(HttpStatus.OK);
+    public boolean healthReady() {
+        return new LDSConsumer(API_LDS).getFrom("/health/ready").getStatusCode().equals(HttpStatus.OK);
     }
 }

--- a/src/main/java/no/ssb/subsetsservice/LDSInterface.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSInterface.java
@@ -64,5 +64,5 @@ public interface LDSInterface {
      */
     ResponseEntity<JsonNode> createSubset(JsonNode subset, String id);
 
-    boolean pingLDSSubsets();
+    boolean healthReady();
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,4 +4,4 @@ management.endpoints.web.base-path=/
 management.endpoints.web.path-mapping.prometheus=metrics
 
 # Logging related configurations
-logging.level.no.ssb.subsetsservice=DEBUG
+logging.level.no.ssb.subsetsservice=INFO

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,4 +4,4 @@ management.endpoints.web.base-path=/
 management.endpoints.web.path-mapping.prometheus=metrics
 
 # Logging related configurations
-logging.level.no.ssb.subsetsservice=INFO
+logging.level.no.ssb.subsetsservice=DEBUG

--- a/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsServiceApplicationTests.java
@@ -85,7 +85,7 @@ class SubsetsServiceApplicationTests {
 		System.out.println(response.getBody());
 		System.out.println("IDs:");
 		for (JsonNode jsonNode : response.getBody()) {
-			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText(), false, false, false).getBody();
+			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText(), true, true, false).getBody();
 			assertEquals(subset.get("id").asText(), jsonNode.get("id").asText());
 			System.out.println(subset.get("id"));
 		}
@@ -99,7 +99,7 @@ class SubsetsServiceApplicationTests {
 		System.out.println(response.getBody());
 		System.out.println("IDs:");
 		for (JsonNode jsonNode : response.getBody()) {
-			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText(), false, false, false).getBody();
+			JsonNode subset = SubsetsController.getInstance().getSubset(jsonNode.get("id").asText(), true, true, false).getBody();
 			assertEquals(subset.get("id").asText(), jsonNode.get("id").asText());
 			System.out.println("ID: "+subset.get("id"));
 


### PR DESCRIPTION
because the health checks do not use the classification/subset apis, the KLASS and LDS base URLs should not include that part, so that they can be reused for health checks.