### PR TITLE
Bugfix - automatically overwrite createdDate on PUT

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -118,10 +118,18 @@ public class SubsetsController {
             ObjectNode editableSubset = Utils.cleanSubsetVersion(newVersionOfSubset).deepCopy();
             editableSubset.put(Field.LAST_UPDATED_DATE, Utils.getNowISO());
             ResponseEntity<JsonNode> mostRecentVersionRE = getSubset(id, true, true, true);
-            ResponseEntity<JsonNode> oldVersionsRE = getVersions(id, true, true, true);
             JsonNode mostRecentVersionOfThisSubset = mostRecentVersionRE.getBody();
+            if (mostRecentVersionOfThisSubset == null)
+                return ErrorHandler.newHttpError("Call for most recent version of subset you PUT did not return a body, and gave code "+mostRecentVersionRE.getStatusCode().toString(), HttpStatus.INTERNAL_SERVER_ERROR, LOG);
+            if (mostRecentVersionOfThisSubset.has(Field.CREATED_DATE)){
+                JsonNode createdDate = mostRecentVersionOfThisSubset.get(Field.CREATED_DATE);
+                editableSubset.put(Field.CREATED_DATE, createdDate.asText());
+            } else {
+                return ErrorHandler.newHttpError("most recent version did not have the createdDate field", HttpStatus.INTERNAL_SERVER_ERROR, LOG);
+            }
+            ResponseEntity<JsonNode> oldVersionsRE = getVersions(id, true, true, true);
             if (mostRecentVersionRE.getStatusCodeValue() == HttpStatus.OK.value()){
-                assert mostRecentVersionOfThisSubset != null && mostRecentVersionOfThisSubset.has(Field.ID) : "no old subset with this id was found in body of response entity";
+                assert mostRecentVersionOfThisSubset.has(Field.ID) : "subset did not have field '"+Field.ID+"' ";
 
                 String oldID = mostRecentVersionOfThisSubset.get(Field.ID).asText();
                 String newID = newVersionOfSubset.get(Field.ID).asText();


### PR DESCRIPTION
@alina-lapina  expects the service to automatically overwrite a subsets createdDate to the correct value (the date of the original POST) when it is updated with PUT.

The client can now give empty/nonexisting createdDate fields, and get away with it.

Even if the createdDate is attempted to be changed by a PUT request, the API will not complain. It will simply overwrite the falsely given value with the old, true value.