### PR TITLE
fixed codesAt. If non-existent validUntil in put/post, insert null

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/Field.java
+++ b/src/main/java/no/ssb/subsetsservice/Field.java
@@ -5,6 +5,7 @@ public class Field {
     public static final String VALID_UNTIL = "validUntil";
     public static final String VERSION = "version";
     public static final String VERSION_VALID_FROM = "versionValidFrom";
+    public static final String VERSION_VALID_UNTIL = "versionValidUntil";
     public static final String VERSION_RATIONALE = "versionRationale";
     public static final String DOCUMENT = "document";
     public static final String CODES = "codes";
@@ -23,5 +24,4 @@ public class Field {
     public static final String CODE = "code";
     public static final String _LINKS = "_links";
     public static final String SELF = "self";
-    public static final String VERSION_VALID_UNTIL = "versionValidUntil";
 }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -351,11 +351,15 @@ public class SubsetsController {
                 }
             } else {
                 // The new version being PUT is neither the first or the last version, but is valid in between existing versions
-                // TODO: Should this be illegal?
+                return ErrorHandler.newHttpError(
+                        "New versions of a subset must be valid either before the previous first version or after the previous last version.",
+                        HttpStatus.BAD_REQUEST,
+                        LOG);
             }
         } else {
             // The new version being put is the new last version
             // If defined, the subset's 'validUntil' in the new version must be the same as the subsets 'versionValidUntil' .
+            editableNewVersionOfSubset.set(Field.VERSION_VALID_UNTIL, editableNewVersionOfSubset.get(Field.VALID_UNTIL));
         }
 
         ResponseEntity<JsonNode> prevPatchOfThisVersionRE = getVersion(id, newVersionString, true, true, true);

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -555,8 +555,6 @@ public class SubsetsController {
                     JsonNode latestPublishedName = publishedVersionExists && latestPublishedVersionNode.has(Field.NAME) ? latestPublishedVersionNode.get(Field.NAME) : null;
                     JsonNode latestPublishedShortName = publishedVersionExists && latestPublishedVersionNode.has(Field.SHORT_NAME) ? latestPublishedVersionNode.get(Field.SHORT_NAME) : null;
                     JsonNode latestPublishedValidUntil = publishedVersionExists && latestPublishedVersionNode.has(Field.VALID_UNTIL) ? latestPublishedVersionNode.get(Field.VALID_UNTIL) : null;
-                    if (latestPublishedValidUntil == null && publishedVersionExists && latestPublishedVersionNode.has(Field.VERSION_VALID_UNTIL))
-                        latestPublishedValidUntil = latestPublishedVersionNode.get(Field.VERSION_VALID_UNTIL);
                     JsonNode firstPublishedValidFrom = firstPublishedVersionExists && firstPublishedVersionNode.has(Field.VALID_FROM) ? firstPublishedVersionNode.get(Field.VALID_FROM) : null;
 
                     ArrayNode majorVersionsObjectNodeArray = mapper.createArrayNode();

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -226,7 +226,7 @@ public class SubsetsController {
                     HttpStatus.BAD_REQUEST,
                     LOG);
 
-        if (!(newVersionOfSubset.get(Field.VALID_FROM).asText().compareTo(newVersionOfSubset.get(Field.VERSION_VALID_FROM).asText()) <= 0))
+        if (newVersionOfSubset.get(Field.VALID_FROM).asText().compareTo(newVersionOfSubset.get(Field.VERSION_VALID_FROM).asText()) > 0)
             return ErrorHandler.newHttpError(
                     "'versionValidFrom' can not be earlier than subset 'validFrom'",
                     HttpStatus.BAD_REQUEST,
@@ -247,7 +247,7 @@ public class SubsetsController {
                     HttpStatus.BAD_REQUEST,
                     LOG);
 
-        if (!(newVersionOfSubset.get(Field.VALID_FROM).asText().compareTo(newVersionOfSubset.get(Field.VERSION_VALID_FROM).asText()) <= 0))
+        if (newVersionOfSubset.get(Field.VALID_FROM).asText().compareTo(newVersionOfSubset.get(Field.VERSION_VALID_FROM).asText()) > 0)
             return ErrorHandler.newHttpError(
                     "'versionValidFrom' can not be earlier than subset 'validFrom'",
                     HttpStatus.BAD_REQUEST,

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -285,7 +285,7 @@ public class SubsetsController {
                             "You can't turn back validUntil, only turn it forward",
                             HttpStatus.BAD_REQUEST,
                             LOG);
-                if (!(newVersionValidFrom.compareTo(lastVersionValidFrom) >= 0))
+                if (newVersionValidFrom.compareTo(lastVersionValidFrom) < 0)
                     return ErrorHandler.newHttpError(
                             "You can only update the validUntil by changing the latest version, or publishing a new latest version",
                             HttpStatus.BAD_REQUEST,

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -120,6 +120,7 @@ public class SubsetsController {
                     LOG);
 
         ObjectNode editableSubset = subsetJson.deepCopy();
+        subsetJson = null;
 
         String isoNow = Utils.getNowISO();
         editableSubset.put(Field.LAST_UPDATED_DATE, isoNow);
@@ -127,11 +128,22 @@ public class SubsetsController {
 
         String versionValidFrom = editableSubset.get(Field.VERSION_VALID_FROM).asText();
         String validFrom = editableSubset.get(Field.VALID_FROM).asText();
+
         if (!versionValidFrom.equals(validFrom)){
             return ErrorHandler.newHttpError(
                     "validFrom must be equal versionValidFrom for the first version of the subset (this one)",
                     HttpStatus.BAD_REQUEST,
                     LOG);
+        }
+
+        if (!editableSubset.has(Field.VALID_UNTIL))
+            editableSubset.set(Field.VALID_UNTIL, null);
+        else if (editableSubset.has(Field.VERSION_VALID_UNTIL)){
+            if (!editableSubset.get(Field.VERSION_VALID_UNTIL).asText().equals(editableSubset.get(Field.VALID_UNTIL).asText()))
+                return ErrorHandler.newHttpError(
+                        "validUntil must be equal versionValidUntil for the first version of the subset (this one)",
+                        HttpStatus.BAD_REQUEST,
+                        LOG);
         }
 
         JsonNode cleanSubset = Utils.cleanSubsetVersion(editableSubset);
@@ -221,7 +233,7 @@ public class SubsetsController {
                     LOG);
 
         if (newVersionOfSubset.has(Field.VALID_UNTIL)
-                && newVersionOfSubset.get(Field.VALID_UNTIL).asText().compareTo(newVersionOfSubset.get(Field.VERSION_VALID_FROM).asText()) <= 0)
+                && !newVersionOfSubset.get(Field.VALID_UNTIL).isNull() && newVersionOfSubset.get(Field.VALID_UNTIL).asText().compareTo(newVersionOfSubset.get(Field.VERSION_VALID_FROM).asText()) <= 0)
             return ErrorHandler.newHttpError(
                     "The subset's 'validUntil' must be set to a date after 'versionValidFrom'",
                     HttpStatus.BAD_REQUEST,
@@ -260,30 +272,19 @@ public class SubsetsController {
 
         ArrayNode versionsArrayNode = Utils.sortByVersionValidFrom(Utils.cleanSubsetVersion(Objects.requireNonNull(oldVersionsRE.getBody())).deepCopy());
         JsonNode mostRecentVersionOfThisSubset = versionsArrayNode.get(0);
-        JsonNode earliestVersionOfThisSubset = versionsArrayNode.get(0);
+        JsonNode earliestVersionOfThisSubset = versionsArrayNode.get(versionsArrayNode.size()-1);
 
         assert mostRecentVersionOfThisSubset.has(Field.ID) : "most recent version of this subset did not have the field '"+Field.ID+"' ";
 
         ObjectNode editableNewVersionOfSubset = Utils.cleanSubsetVersion(newVersionOfSubset).deepCopy();
+        newVersionOfSubset = null;
         editableNewVersionOfSubset.put(Field.LAST_UPDATED_DATE, Utils.getNowISO());
         JsonNode createdDate = mostRecentVersionOfThisSubset.get(Field.CREATED_DATE);
         editableNewVersionOfSubset.set(Field.CREATED_DATE, createdDate);
 
         if (!editableNewVersionOfSubset.has(Field.VALID_UNTIL)){
-            //TODO: Add the validUntil date from the existing published version, if exists?
-            JsonNode validUntil = null;
-            if (thisSubsetIsPublishedFromBefore){
-                JsonNode publishedVersion = oldPublishedVersionsRE.getBody().get(0);
-                if (publishedVersion.has(Field.VALID_UNTIL))
-                    validUntil = publishedVersion.get(Field.VALID_UNTIL);
-            }
-            if (validUntil == null && mostRecentVersionOfThisSubset.has(Field.VALID_UNTIL)) {
-                validUntil = mostRecentVersionOfThisSubset.get(Field.VALID_UNTIL);
-            }
-            if (validUntil != null)
-                editableNewVersionOfSubset.set(Field.VALID_UNTIL, validUntil);
-            else
-                LOG.error("The PUT version as well as the most recent published version and the most recent version overall had no validUntil field, so this version will have to validUntil");
+            editableNewVersionOfSubset.set(Field.VALID_UNTIL, null);
+            LOG.info("The PUT version did not have a validUntil value defined. validUntil was defined and set to null");
         }
 
         String oldID = mostRecentVersionOfThisSubset.get(Field.ID).asText();
@@ -668,7 +669,9 @@ public class SubsetsController {
         metricsService.incrementGETCounter();
 
         if (Utils.isClean(id)){
-            if (from == null && to == null){
+            boolean isFromDate = from != null;
+            boolean isToDate = to != null;
+            if (!isFromDate && !isToDate){
                 LOG.debug("getting all codes of the latest/current version of subset "+id);
                 ResponseEntity<JsonNode> subsetResponseEntity = getSubset(id, includeDrafts, includeFuture, rankedUrnOnly);
                 JsonNode responseBodyJSON = subsetResponseEntity.getBody();
@@ -686,8 +689,6 @@ public class SubsetsController {
                 return ErrorHandler.newHttpError("response body of getSubset with id "+id+" was null, so could not get codes.", HttpStatus.INTERNAL_SERVER_ERROR, LOG);
             }
 
-            boolean isFromDate = from != null;
-            boolean isToDate = to != null;
             if ((!isFromDate || Utils.isYearMonthDay(from)) && (!isToDate || Utils.isYearMonthDay(to))){ // If a date is given as param, it must be valid format
                 // If a date interval is specified using 'from' and 'to' query parameters
                 ResponseEntity<JsonNode> versionsResponseEntity = getVersions(id, includeFuture, includeDrafts, rankedUrnOnly);
@@ -707,35 +708,38 @@ public class SubsetsController {
                         JsonNode lastVersion = versionsArrayNode.get(0).get(Field.DOCUMENT);
                         ArrayNode intersectionValidCodesInIntervalArrayNode = mapper.createArrayNode();
                         // Check if first version includes fromDate, and last version includes toDate. If not, then return an empty list.
-                        String firstVersionValidFromString = firstVersion.get(Field.VALID_FROM).textValue().split("T")[0];
-                        String lastVersionValidUntilString = lastVersion.get(Field.VALID_UNTIL).textValue().split("T")[0];
-                        LOG.debug("First version valid from: " + firstVersionValidFromString);
-                        LOG.debug("Last version valid until: " + lastVersionValidUntilString);
 
                         boolean isFirstValidAtOrBeforeFromDate = true; // If no "from" date is given, version is automatically valid at or before "from" date
-                        if (isFromDate)
+                        if (isFromDate) {
+                            String firstVersionValidFromString = firstVersion.get(Field.VALID_FROM).textValue().split("T")[0];
+                            LOG.debug("First version valid from: " + firstVersionValidFromString);
                             isFirstValidAtOrBeforeFromDate = firstVersionValidFromString.compareTo(from) <= 0;
+                        }
                         LOG.debug("isFirstValidAtOrBeforeFromDate? " + isFirstValidAtOrBeforeFromDate);
 
                         boolean isLastValidAtOrAfterToDate = true; // If no "to" date is given, it is automatically valid at or after "to" date
-                        if (isToDate)
+                        if (isToDate && lastVersion.has(Field.VALID_UNTIL) && !lastVersion.get(Field.VALID_UNTIL).isNull()) {
+                            String lastVersionValidUntilString = lastVersion.get(Field.VALID_UNTIL).textValue().split("T")[0];
+                            LOG.debug("Last version valid until: " + lastVersionValidUntilString);
                             isLastValidAtOrAfterToDate = lastVersionValidUntilString.compareTo(to) >= 0;
+                        }
                         LOG.debug("isLastValidAtOrAfterToDate? " + isLastValidAtOrAfterToDate);
 
                         if (isFirstValidAtOrBeforeFromDate && isLastValidAtOrAfterToDate) {
                             for (JsonNode subsetVersion : versionsArrayNode) {
                                 if (includeDrafts || subsetVersion.get(Field.ADMINISTRATIVE_STATUS).asText().equals(Field.OPEN)){
                                     // if this version has any overlap with the valid interval . . .
-                                    String validFromDateString = subsetVersion.get(Field.VALID_FROM).textValue().split("T")[0];
-                                    String validUntilDateString = subsetVersion.get(Field.VALID_UNTIL).textValue().split("T")[0];
-
                                     boolean validUntilGTFrom = true;
-                                    if (isFromDate)
+                                    if (isFromDate) {
+                                        String validUntilDateString = subsetVersion.get(Field.VALID_UNTIL).textValue().split("T")[0];
                                         validUntilGTFrom = validUntilDateString.compareTo(from) > 0;
+                                    }
 
                                     boolean validFromLTTo = true;
-                                    if (isToDate)
+                                    if (isToDate) {
+                                        String validFromDateString = subsetVersion.get(Field.VALID_FROM).textValue().split("T")[0];
                                         validFromLTTo = validFromDateString.compareTo(to) < 0;
+                                    }
 
                                     if (validUntilGTFrom || validFromLTTo) {
                                         LOG.debug("Version " + subsetVersion.get(Field.VERSION) + " is valid in the interval, so codes will be added to map");
@@ -788,19 +792,18 @@ public class SubsetsController {
 
         if (date != null && Utils.isClean(id) && (Utils.isYearMonthDay(date))){
             ResponseEntity<JsonNode> versionsResponseEntity = getVersions(id, includeFuture, includeDrafts, rankedUrnOnly);
-            JsonNode responseBodyJSON = versionsResponseEntity.getBody();
-            if (responseBodyJSON != null){
-                if (responseBodyJSON.isArray()) {
-                    ArrayNode arrayNode = (ArrayNode) responseBodyJSON;
-                    for (JsonNode jsonNode : arrayNode) {
-                        JsonNode version = jsonNode.get(Field.DOCUMENT);
-                        String entryValidFrom = version.get(Field.VALID_FROM).textValue();
-                        String entryValidUntil = version.get(Field.VALID_UNTIL).textValue();
+            JsonNode versionsResponseBodyJSON = versionsResponseEntity.getBody();
+            if (versionsResponseBodyJSON != null){
+                if (versionsResponseBodyJSON.isArray()) {
+                    ArrayNode versionsArrayNode = (ArrayNode) versionsResponseBodyJSON;
+                    for (JsonNode versionJsonNode : versionsArrayNode) {
+                        String entryValidFrom = versionJsonNode.get(Field.VALID_FROM).textValue();
+                        String entryValidUntil = versionJsonNode.get(Field.VALID_UNTIL).textValue();
                         if (entryValidFrom.compareTo(date) <= 0 && entryValidUntil.compareTo(date) >= 0 ){
-                            LOG.debug("Found valid codes at "+date+". "+version.get(Field.CODES).size());
+                            LOG.debug("Found valid codes at "+date+". "+versionJsonNode.get(Field.CODES).size());
                             ObjectMapper mapper = new ObjectMapper();
                             ArrayNode codeArray = mapper.createArrayNode();
-                            version.get(Field.CODES).forEach(e -> codeArray.add(e.get(Field.URN)));
+                            versionJsonNode.get(Field.CODES).forEach(e -> codeArray.add(e.get(Field.URN)));
                             return new ResponseEntity<>(codeArray, HttpStatus.OK);
                         }
                     }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -92,13 +92,6 @@ public class SubsetsController {
                     HttpStatus.BAD_REQUEST,
                     LOG);
 
-        if (subsetJson.has(Field.VALID_UNTIL) && subsetJson.has(Field.VERSION_VALID_UNTIL)
-                && subsetJson.get(Field.VALID_UNTIL).asText().compareTo(subsetJson.get(Field.VERSION_VALID_UNTIL).asText()) != 0)
-            return ErrorHandler.newHttpError(
-                    "'versionValidUntil' can not be different from the subset's 'validUntil'",
-                    HttpStatus.BAD_REQUEST,
-                    LOG);
-
         if (subsetJson.has(Field.VALID_UNTIL)
                 && subsetJson.get(Field.VALID_UNTIL).asText().compareTo(subsetJson.get(Field.VERSION_VALID_FROM).asText()) <= 0)
             return ErrorHandler.newHttpError(
@@ -138,13 +131,8 @@ public class SubsetsController {
 
         if (!editableSubset.has(Field.VALID_UNTIL))
             editableSubset.set(Field.VALID_UNTIL, null);
-        else if (editableSubset.has(Field.VERSION_VALID_UNTIL)){
-            if (!editableSubset.get(Field.VERSION_VALID_UNTIL).asText().equals(editableSubset.get(Field.VALID_UNTIL).asText()))
-                return ErrorHandler.newHttpError(
-                        "validUntil must be equal versionValidUntil for the first version of the subset (this one)",
-                        HttpStatus.BAD_REQUEST,
-                        LOG);
-        }
+
+        editableSubset.set(Field.VERSION_VALID_UNTIL, editableSubset.get(Field.VALID_UNTIL));
 
         JsonNode cleanSubset = Utils.cleanSubsetVersion(editableSubset);
         ResponseEntity<JsonNode> responseEntity = new LDSFacade().createSubset(cleanSubset, id);

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -376,6 +376,7 @@ public class SubsetsController {
 
                 String[] changeableFieldsInPublishedVersion = {
                         Field.VERSION_RATIONALE,
+                        Field.VALID_FROM,
                         Field.VALID_UNTIL,
                         Field.VERSION_VALID_UNTIL,
                         Field.LAST_UPDATED_BY,

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -327,13 +327,6 @@ public class SubsetsController {
                         "It is not allowed to submit a version with versionValidFrom equal to that of an existing version.",
                         HttpStatus.BAD_REQUEST,
                         LOG);
-            if (!subsetVersionJsonNode.get(Field.VERSION).asText().equals(editableNewVersionOfSubset.get(Field.VERSION).asText())
-                    && newVersionValidFrom.compareTo(versionValidFrom) < 0
-                    && editableNewVersionOfSubset.has(Field.VERSION_VALID_UNTIL) && editableNewVersionOfSubset.get(Field.VALID_UNTIL).asText().compareTo(versionValidFrom) > 0)
-                return ErrorHandler.newHttpError(
-                        "It is not allowed for subset version to overlap in validity periods",
-                        HttpStatus.BAD_REQUEST,
-                        LOG);
         }
 
         String mostRecentVersionValidFrom = mostRecentVersionOfThisSubset.get(Field.VERSION_VALID_FROM).asText();

--- a/src/test/java/no/ssb/subsetsservice/SubsetsControllerTest.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsControllerTest.java
@@ -263,7 +263,9 @@ class SubsetsControllerTest {
 
         JsonNode subsetJsonNode = getSubset(fv0_4);
         ResponseEntity<JsonNode> postRE = instance.postSubset(subsetJsonNode);
-        assertEquals(HttpStatus.BAD_REQUEST, postRE.getStatusCode());
+        // posted versionValidUntil should be ignored by the server because it is generated automatically
+        // This means the subset should be created even if versionValidFrom is wrong
+        assertEquals(HttpStatus.CREATED, postRE.getStatusCode());
     }
 
     @Test
@@ -273,7 +275,9 @@ class SubsetsControllerTest {
 
         JsonNode subsetJsonNode = getSubset(fv0_5);
         ResponseEntity<JsonNode> postRE = instance.postSubset(subsetJsonNode);
-        assertEquals(HttpStatus.BAD_REQUEST, postRE.getStatusCode());
+        // posted versionValidUntil should be ignored by the server because it is generated automatically
+        // This means the subset should be created even if versionValidFrom is wrong
+        assertEquals(HttpStatus.CREATED, postRE.getStatusCode());
     }
 
     @Test

--- a/src/test/java/no/ssb/subsetsservice/SubsetsControllerTest.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsControllerTest.java
@@ -33,8 +33,10 @@ class SubsetsControllerTest {
     File fv1_2 = new File("src/test/resources/subset_examples/uttrekk_for_publiseringstesting_v1.2.json"); // try to change validFrom and versionValidFrom to a later date
     File fv1_3 = new File("src/test/resources/subset_examples/uttrekk_for_publiseringstesting_v1.3.json"); // try to change versionValidFrom to a later date than validFrom, even if this is only version of subset
     File fv1_4 = new File("src/test/resources/subset_examples/uttrekk_for_publiseringstesting_v1.4.json"); // from 1.0 change validUntil, versionValidUntil and versionRationale
+    File fv1_5 = new File("src/test/resources/subset_examples/uttrekk_for_publiseringstesting_v1.5.json"); // no versionValidUntil given
     File fv2_0 = new File("src/test/resources/subset_examples/uttrekk_for_publiseringstesting_v2.json");
     File fv2_1 = new File("src/test/resources/subset_examples/uttrekk_for_publiseringstesting_v2.1.json"); // OPEN, with same changes as 0.91
+    File fv2_2 = new File("src/test/resources/subset_examples/uttrekk_for_publiseringstesting_v2.2.json"); // no validUntil or versionValidUntil
     File fv3_0 = new File("src/test/resources/subset_examples/uttrekk_for_publiseringstesting_v3.0.json"); // A valid DRAFT
     File fv3_1 = new File("src/test/resources/subset_examples/uttrekk_for_publiseringstesting_v3.1.json"); // same versionValidFrom as 1.0
     File fv4_0 = new File("src/test/resources/subset_examples/uttrekk_for_publiseringstesting_v4.0.json"); // DRAFT with no codes
@@ -59,8 +61,10 @@ class SubsetsControllerTest {
         assertTrue(fv1_2.exists());
         assertTrue(fv1_3.exists());
         assertTrue(fv1_4.exists());
+        assertTrue(fv1_5.exists());
         assertTrue(fv2_0.exists());
         assertTrue(fv2_1.exists());
+        assertTrue(fv2_2.exists());
         assertTrue(fv3_0.exists());
         assertTrue(fv3_1.exists());
         assertTrue(fv4_0.exists());
@@ -278,6 +282,33 @@ class SubsetsControllerTest {
         // posted versionValidUntil should be ignored by the server because it is generated automatically
         // This means the subset should be created even if versionValidFrom is wrong
         assertEquals(HttpStatus.CREATED, postRE.getStatusCode());
+    }
+
+    @Test
+    void postOpenThenPutDifferentValidUntil(){
+        SubsetsController instance = SubsetsController.getInstance();
+        instance.deleteAll();
+
+        JsonNode subsetJsonNode = getSubset(fv1_5);
+        ResponseEntity<JsonNode> postRE = instance.postSubset(subsetJsonNode);
+        assertEquals(HttpStatus.CREATED, postRE.getStatusCode());
+
+
+        JsonNode subsetJsonNode2 = getSubset(fv2_2);
+        String id = subsetJsonNode2.get(Field.ID).asText();
+        ResponseEntity<JsonNode> putRE = instance.putSubset(id, subsetJsonNode2);
+
+        assertEquals(HttpStatus.OK, putRE.getStatusCode());
+        ResponseEntity<JsonNode> versions = instance.getVersions(
+                subsetJsonNode.get(Field.ID).asText(),
+                true,
+                false,
+                true);
+        ArrayNode versionsArr = (ArrayNode) versions.getBody();
+        for (JsonNode version : versionsArr){
+
+            assertTrue(!version.has(Field.VALID_UNTIL) || version.get(Field.VALID_UNTIL).isNull() || version.get(Field.VALID_UNTIL).asText().isBlank());
+        }
     }
 
     @Test

--- a/src/test/resources/subset_examples/uttrekk_for_publiseringstesting_v1.5.json
+++ b/src/test/resources/subset_examples/uttrekk_for_publiseringstesting_v1.5.json
@@ -1,19 +1,30 @@
 {
-    "administrativeStatus": "OPEN",
     "id": "uttrekk_for_publiseringstesting",
-    "version": "2",
+    "shortName": "Test av Publisering",
     "name": [
         {
-            "languageText": "Uttrekk for Testing av Publisering og Endring, endring av draft",
+            "languageText": "Uttrekk for Testing av Publisering og Endring",
             "languageCode": "nb"
         }
     ],
-    "shortName": "Test av Publisering, endring draft",
-    "validFrom": "2020-08-08T00:00:00.000Z",
-    "validUntil": "2020-11-11T00:00:00.000Z",
-    "versionValidFrom": "2020-10-10T00:00:00.000Z",
-    "versionValidUntil": "2020-11-11T00:00:00.000Z",
+    "description": [
+        {
+            "languageText": "Test av publisering, endringer og versjonering",
+            "languageCode": "nb"
+        }
+    ],
     "createdBy": "702 - Seksjon for IT-arkitektur",
+    "validFrom": "2020-08-08T00:00:00.000Z",
+    "validUntil": "2020-09-09T00:00:00.000Z",
+    "version": "1",
+    "administrativeStatus": "OPEN",
+    "versionValidFrom": "2020-08-08T00:00:00.000Z",
+    "versionRationale": [
+        {
+            "languageText": "Dette er versjonens rasjonale.",
+            "languageCode": "nb"
+        }
+    ],
     "administrativeDetails": [
         {
             "administrativeDetailType": "ANNOTATION",
@@ -28,18 +39,6 @@
                 "urn:ssb:klass-api:classifications:17",
                 "urn:ssb:klass-api:classifications:19"
             ]
-        }
-    ],
-    "description": [
-        {
-            "languageText": "Test av publisering, endringer og versjonering. Test endring",
-            "languageCode": "nb"
-        }
-    ],
-    "versionRationale": [
-        {
-            "languageText": "Dette er versjonens rasjonale. Test endring",
-            "languageCode": "nb"
         }
     ],
     "codes": [
@@ -142,6 +141,40 @@
             "parentCode": "031",
             "level": "4",
             "name": "Menige",
+            "shortName": "",
+            "presentationName": ""
+        },
+        {
+            "code": "0210",
+            "urn": "urn:ssb:klass-api:classifications:7:code:0210",
+            "rank": 7,
+            "classificationId": "7",
+            "_links": {
+                "self": {
+                    "href": "https://data.ssb.no/api/klass/v1//classifications/7/codesAt.json?date=2020-08-10&selectCodes=0210"
+                }
+            },
+            "classification": "undefined - Standard for yrkesklassifisering",
+            "parentCode": "021",
+            "level": "4",
+            "name": "Befal med sersjant grad",
+            "shortName": "",
+            "presentationName": ""
+        },
+        {
+            "code": "0110",
+            "urn": "urn:ssb:klass-api:classifications:7:code:0110",
+            "rank": 8,
+            "classificationId": "7",
+            "_links": {
+                "self": {
+                    "href": "https://data.ssb.no/api/klass/v1//classifications/7/codesAt.json?date=2020-08-10&selectCodes=0110"
+                }
+            },
+            "classification": "undefined - Standard for yrkesklassifisering",
+            "parentCode": "011",
+            "level": "4",
+            "name": "Offiserer fra fenrik og høyere grad",
             "shortName": "",
             "presentationName": ""
         }

--- a/src/test/resources/subset_examples/uttrekk_for_publiseringstesting_v2.2.json
+++ b/src/test/resources/subset_examples/uttrekk_for_publiseringstesting_v2.2.json
@@ -10,9 +10,7 @@
     ],
     "shortName": "Test av Publisering, endring draft",
     "validFrom": "2020-08-08T00:00:00.000Z",
-    "validUntil": "2020-11-11T00:00:00.000Z",
     "versionValidFrom": "2020-10-10T00:00:00.000Z",
-    "versionValidUntil": "2020-11-11T00:00:00.000Z",
     "createdBy": "702 - Seksjon for IT-arkitektur",
     "administrativeDetails": [
         {


### PR DESCRIPTION
If a subset version without a "validUntil" field is POSTed or PUT, that is taken as an explicit statement that the subset validity period is open ended. When requested with a GET, the validUntil field will be present with the value "null" if it is open ended.

versionValidUntil is managed by the server
- If a subset is POSTED, versionValidUntil is set automatically to be the same as validUntil.
- If a subset is PUT, versionValidUntil is set automatically to validUntil for versions that are the new last version, and to the versionValidFrom of the next version for new versions that are the new first version. The versionValidFrom value of a submitted subset or version is ignored.

If a PUT subset version has changed the validFrom or validUntil, make sure it is following some constraints:
- The 'validFrom' field must at all times match the 'versionValidFrom' of the earliest version
- You can't turn back validUntil, only turn it forward
- You can only update the validUntil by changing the latest version, or publishing a new latest version

When subset versions are retrieved, validFrom is taken from the earliest version, and validUntil is taken from the latest version. The validFrom and validUntil of all versions are overwritten by these values.

https://jira.ssb.no/browse/KF-410 and https://jira.ssb.no/browse/KF-411 should be fixed, now.

Fixed a fault in the codesAt method that was introduced earlier when refactoring.

Fixed a fault in the overwriting of validUntil fields based on the latest version that might have caused an error.

Also cleaned up some code