### PR TITLE
New schema usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.12</version>
+            <version>4.5.13</version>
         </dependency>
 
         <dependency>
@@ -116,6 +116,13 @@
             <artifactId>google-cloud-secretmanager</artifactId>
             <version>1.1.2</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.4.8</version>
+        </dependency>
+        
     </dependencies>
 
     <build>

--- a/src/main/java/no/ssb/subsetsservice/Field.java
+++ b/src/main/java/no/ssb/subsetsservice/Field.java
@@ -26,4 +26,6 @@ public class Field {
     public static final String SELF = "self";
     public static final String SUBSET = "subset";
     public static final String CLASSIFICATION_TYPE = "classificationType";
+    public static final String VERSIONS = "versions";
+    public static final String LAST_MODIFIED = "lastModified";
 }

--- a/src/main/java/no/ssb/subsetsservice/Field.java
+++ b/src/main/java/no/ssb/subsetsservice/Field.java
@@ -29,4 +29,6 @@ public class Field {
     public static final String VERSIONS = "versions";
     public static final String LAST_MODIFIED = "lastModified";
     public static final String SUBSET_ID = "subsetId";
+    public static final String LAST_MODIFIED_BY = "lastModifiedBy";
+    public static final String SERIES_ID = "seriesId";
 }

--- a/src/main/java/no/ssb/subsetsservice/Field.java
+++ b/src/main/java/no/ssb/subsetsservice/Field.java
@@ -24,4 +24,6 @@ public class Field {
     public static final String CODE = "code";
     public static final String _LINKS = "_links";
     public static final String SELF = "self";
+    public static final String SUBSET = "subset";
+    public static final String CLASSIFICATION_TYPE = "classificationType";
 }

--- a/src/main/java/no/ssb/subsetsservice/Field.java
+++ b/src/main/java/no/ssb/subsetsservice/Field.java
@@ -28,4 +28,5 @@ public class Field {
     public static final String CLASSIFICATION_TYPE = "classificationType";
     public static final String VERSIONS = "versions";
     public static final String LAST_MODIFIED = "lastModified";
+    public static final String SUBSET_ID = "subsetId";
 }

--- a/src/main/java/no/ssb/subsetsservice/HealthController.java
+++ b/src/main/java/no/ssb/subsetsservice/HealthController.java
@@ -2,6 +2,7 @@ package no.ssb.subsetsservice;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,12 +19,12 @@ public class HealthController {
 
     private HealthController(){}
 
-    @RequestMapping("/health/alive")
+    @GetMapping("/health/alive")
     public ResponseEntity<String> alive() {
         return new ResponseEntity<>("The service is alive!", HttpStatus.OK);
     }
 
-    @RequestMapping("/health/ready")
+    @GetMapping("/health/ready")
     public ResponseEntity<String> ready() {
         boolean klassReady = new KlassURNResolver().pingKLASSClassifications();
         boolean ldsReady = new LDSFacade().healthReady();

--- a/src/main/java/no/ssb/subsetsservice/HelloController.java
+++ b/src/main/java/no/ssb/subsetsservice/HelloController.java
@@ -1,6 +1,6 @@
 package no.ssb.subsetsservice;
 
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -23,7 +23,7 @@ public class HelloController {
                     " |_|\\_\\______/_/    \\_\\_____/_____/  |_____/ \\__,_|_.__/|___/\\___|\\__|___/ /_/    \\_\\_|   |_____|   \\_/|____|\n</pre>" +
                     "                                                                                                             ";
 
-    @RequestMapping("/hello")
+    @GetMapping("/hello")
     public String hello() {
         return banner;
 

--- a/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
@@ -160,14 +160,14 @@ public class LDSConsumer {
             int status = response.getStatusLine().getStatusCode();
             HttpStatus httpStatus = HttpStatus.resolve(status);
             LOG.debug("PUT to "+LDS_URL+additional+" - Status: "+httpStatus.toString());
-            if (!httpStatus.equals(HttpStatus.CREATED)){
+            if (!httpStatus.equals(HttpStatus.CREATED) && !httpStatus.equals(HttpStatus.OK)){
                 String responseBodyString = EntityUtils.toString(entity);
                 return ErrorHandler.newHttpError(
                         "LDS returned code "+httpStatus+" and body "+responseBodyString,
                         HttpStatus.INTERNAL_SERVER_ERROR,
                         LOG);
             }
-            return new ResponseEntity<>(json, HttpStatus.CREATED);
+            return new ResponseEntity<>(json, httpStatus);
         } catch (IOException e) {
             e.printStackTrace();
             return ErrorHandler.newHttpError(

--- a/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
@@ -7,6 +7,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.http.conn.HttpHostConnectException;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
@@ -22,6 +23,7 @@ import org.springframework.web.client.RestTemplate;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
+import java.net.ConnectException;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
@@ -88,7 +90,11 @@ public class LDSConsumer {
         HttpGet httpGet = new HttpGet(LDS_URL + additional);
         CloseableHttpResponse response1 = null;
         try {
-            response1 = httpclient.execute(httpGet);
+            try {
+                response1 = httpclient.execute(httpGet);
+            } catch (ConnectException e){
+                return ErrorHandler.newHttpError("Could not retrieve "+LDS_URL+additional+" because of an exception: "+e.toString(), HttpStatus.INTERNAL_SERVER_ERROR, LOG);
+            }
             System.out.println(response1.getStatusLine());
             System.out.println(response1.toString());
             HttpEntity entity1 = response1.getEntity();
@@ -112,12 +118,15 @@ public class LDSConsumer {
     }
 
     ResponseEntity<JsonNode> postTo(String additional, JsonNode json){
+        String fullURLString = LDS_URL+additional;
+        LOG.debug("Building request for POSTing to "+fullURLString);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
         org.springframework.http.HttpEntity<JsonNode> request = new org.springframework.http.HttpEntity<>(json, headers);
-        ResponseEntity<JsonNode> response = new RestTemplate().postForEntity(LDS_URL+additional, request, JsonNode.class);
-        LOG.debug("POST to "+LDS_URL+additional+" - Status: "+response.getStatusCodeValue()+" "+response.getStatusCode().name());
+        LOG.debug("POSTing to "+fullURLString);
+        ResponseEntity<JsonNode> response = new RestTemplate().postForEntity(fullURLString, request, JsonNode.class);
+        LOG.debug("POST to "+fullURLString+" - Status: "+response.getStatusCodeValue()+" "+response.getStatusCode().name());
         return response;
     }
 
@@ -150,9 +159,15 @@ public class LDSConsumer {
             HttpEntity entity = response.getEntity();
             int status = response.getStatusLine().getStatusCode();
             HttpStatus httpStatus = HttpStatus.resolve(status);
-            JsonNode jsonNode = new ObjectMapper().readTree(entity.getContent());
-            LOG.debug("POST to "+LDS_URL+additional+" - Status: "+httpStatus.toString());
-            return new ResponseEntity<>(jsonNode, httpStatus);
+            LOG.debug("PUT to "+LDS_URL+additional+" - Status: "+httpStatus.toString());
+            if (!httpStatus.equals(HttpStatus.CREATED)){
+                String responseBodyString = EntityUtils.toString(entity);
+                return ErrorHandler.newHttpError(
+                        "LDS returned code "+httpStatus+" and body "+responseBodyString,
+                        HttpStatus.INTERNAL_SERVER_ERROR,
+                        LOG);
+            }
+            return new ResponseEntity<>(json, HttpStatus.CREATED);
         } catch (IOException e) {
             e.printStackTrace();
             return ErrorHandler.newHttpError(

--- a/src/main/java/no/ssb/subsetsservice/LDSFacade.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSFacade.java
@@ -136,7 +136,7 @@ public class LDSFacade implements LDSInterface {
         if (!putLinkRE.getStatusCode().equals(HttpStatus.OK)){
             return ErrorHandler.newHttpError("Trying to PUT a link between the subset Series and subset Version in LDS failed, with status code "+putLinkRE.getStatusCode(), putLinkRE.getStatusCode(), LoggerFactory.getLogger(LDSFacade.class));
         }
-        return putLinkRE;
+        return new ResponseEntity<>(versionJsonNode, HttpStatus.OK);
     }
 
     /**

--- a/src/main/java/no/ssb/subsetsservice/LDSFacade.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSFacade.java
@@ -97,7 +97,13 @@ public class LDSFacade implements LDSInterface {
     }
 
     public ResponseEntity<JsonNode> editSubset(JsonNode subset, String id){
-        return new LDSConsumer(API_LDS).putTo(SUBSETS_API+"/" + id, subset);
+        ResponseEntity<JsonNode> postRE = new LDSConsumer(API_LDS).postTo(SUBSETS_API+"/" + id, subset);
+        HttpStatus status = postRE.getStatusCode();
+        if (status.is2xxSuccessful())
+            status = HttpStatus.OK;
+        if (postRE.hasBody())
+            return new ResponseEntity<>(postRE.getBody(), postRE.getHeaders(), status);
+        return new ResponseEntity<>(postRE.getHeaders(), status);
     }
 
     public ResponseEntity<JsonNode> createSubset(JsonNode subset, String id){

--- a/src/main/java/no/ssb/subsetsservice/LDSFacade.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSFacade.java
@@ -58,6 +58,11 @@ public class LDSFacade implements LDSInterface {
         return new ResponseEntity<>(versionArrayNode, HttpStatus.OK);
     }
 
+    /**
+     * Get a specific subset version by its UID, without going through the subset series.
+     * @param versionId is the UID for the version, unique among all versions, that is used in LDS
+     * @return
+     */
     public ResponseEntity<JsonNode> getVersionByID(String versionId){
         return new LDSConsumer(API_LDS).getFrom(VERSIONS_API+"/"+versionId);
     }
@@ -124,5 +129,21 @@ public class LDSFacade implements LDSInterface {
             return ErrorHandler.newHttpError("Trying to PUT a link between the subset Series and subset Version in LDS failed, with status code "+putLinkRE.getStatusCode(), putLinkRE.getStatusCode(), LoggerFactory.getLogger(LDSFacade.class));
         }
         return putLinkRE;
+    }
+
+    /**
+     * versionLink should be on the form "/ClassificationSubsetVersion/{versionUID}"
+     * @param versionLink
+     * @return
+     */
+    public ResponseEntity<JsonNode> resolveVersionLink(String versionLink) {
+        String[] splitOnSlash = versionLink.split("/");
+        if (!splitOnSlash[1].equals("ClassificationSubsetVersion"))
+            throw new IllegalArgumentException("versionLink must be on format '/ClassificationSubsetVersion/{versionUID}'");
+        String versionID = splitOnSlash[2];
+        if (!Utils.isClean(versionID))
+            throw new IllegalArgumentException("versionID must be clean (no special characters except '-' and '_')");
+        ResponseEntity<JsonNode> versionRE = new LDSFacade().getVersionByID(versionID);
+        return null;
     }
 }

--- a/src/main/java/no/ssb/subsetsservice/LDSFacade.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSFacade.java
@@ -13,7 +13,9 @@ import java.util.List;
 public class LDSFacade implements LDSInterface {
 
     String API_LDS = "";
-    String SUBSETS_API = "/ns/ClassificationSubset";
+    String SUBSETS_API =    "/ns/ClassificationSubset";
+    String SERIES_API =     "/ns/ClassificationSubsetSeries";
+    String VERSIONS_API =   "/ns/ClassificationSubsetVersion";
 
     LDSFacade(){}
 
@@ -41,6 +43,30 @@ public class LDSFacade implements LDSInterface {
             throw new HttpClientErrorException(HttpStatus.INTERNAL_SERVER_ERROR, "GET all subsets body was null");
         }
         throw new HttpClientErrorException(allSubsetsRE.getStatusCode());
+    }
+
+    public ResponseEntity<JsonNode> getVersionsInSubsetWithID(String subsetId){
+        ResponseEntity<JsonNode> seriesRE = new LDSConsumer(API_LDS).getFrom(SERIES_API+"/"+subsetId);
+        JsonNode subsetSeriesJsonNode = seriesRE.getBody();
+        ArrayNode versionArrayNode = subsetSeriesJsonNode.get("versions").deepCopy();
+        /*
+        for (JsonNode version : versionArrayNode){
+            String versionID = version.get("_links").get("self").get("href").asText();
+        }
+        */
+        return new ResponseEntity<>(versionArrayNode, HttpStatus.OK);
+    }
+
+    public ResponseEntity<JsonNode> getVersionByID(String versionId){
+        return new LDSConsumer(API_LDS).getFrom(VERSIONS_API+"/"+versionId);
+    }
+
+    public ResponseEntity<JsonNode> getSubsetSeries(String id){
+        return new LDSConsumer(API_LDS).getFrom(SERIES_API+"/"+id);
+    }
+
+    public ResponseEntity<JsonNode> getAllSubsetSeries(){
+        return new LDSConsumer(API_LDS).getFrom(SERIES_API+"");
     }
 
     public ResponseEntity<JsonNode> getLastUpdatedVersionOfAllSubsets(){

--- a/src/main/java/no/ssb/subsetsservice/LDSFacade.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSFacade.java
@@ -102,6 +102,10 @@ public class LDSFacade implements LDSInterface {
        new LDSConsumer(API_LDS).delete(url);
     }
 
+    public ResponseEntity<JsonNode> editSeries(JsonNode series, String id) {
+        return new LDSConsumer(API_LDS).putTo(SERIES_API+"/" + id, series);
+    }
+
     public void deleteAllSubsets(){
         List<String> idList = getAllSubsetIDs();
         LoggerFactory.getLogger(LDSFacade.class).info("DELETE all "+idList.size()+" subset(s) from LDS");

--- a/src/main/java/no/ssb/subsetsservice/LDSFacade.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSFacade.java
@@ -146,4 +146,9 @@ public class LDSFacade implements LDSInterface {
         ResponseEntity<JsonNode> versionRE = new LDSFacade().getVersionByID(versionID);
         return null;
     }
+
+    @Override
+    public ResponseEntity<JsonNode> getSubsetSeriesSchema() {
+        return new LDSConsumer(API_LDS).getFrom(SERIES_API+"/?schema");
+    }
 }

--- a/src/main/java/no/ssb/subsetsservice/LDSFacade.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSFacade.java
@@ -126,17 +126,17 @@ public class LDSFacade implements LDSInterface {
         idList.forEach(this::deleteSubset);
     }
 
-    public ResponseEntity<JsonNode> putVersionInSeries(String id, String versionID, JsonNode versionJsonNode) {
-        String versionUID = id+"_"+versionID;
-        ResponseEntity<JsonNode> putVersionRE = new LDSConsumer(API_LDS).putTo(VERSIONS_API+"/"+versionUID, versionJsonNode);
-        if (!putVersionRE.getStatusCode().equals(HttpStatus.CREATED)){
+    public ResponseEntity<JsonNode> postVersionInSeries(String seriesID, String versionNr, JsonNode versionJsonNode) {
+        String versionUID = seriesID+"_"+versionNr;
+        ResponseEntity<JsonNode> putVersionRE = new LDSConsumer(API_LDS).postTo(VERSIONS_API+"/"+versionUID, versionJsonNode);
+        if (!putVersionRE.getStatusCode().equals(HttpStatus.OK)){
             return ErrorHandler.newHttpError("Trying to PUT a subset version to LDS failed with status code "+putVersionRE.getStatusCode(), putVersionRE.getStatusCode(), LoggerFactory.getLogger(LDSFacade.class));
         }
-        ResponseEntity<JsonNode> putLinkRE = new LDSConsumer(API_LDS).putTo(SERIES_API+"/"+id+"/versions/ClassificationSubsetVersion/"+versionUID, new ObjectMapper().createObjectNode());
+        ResponseEntity<JsonNode> putLinkRE = new LDSConsumer(API_LDS).postTo(SERIES_API+"/"+seriesID+"/versions/ClassificationSubsetVersion/"+versionUID, new ObjectMapper().createObjectNode());
         if (!putLinkRE.getStatusCode().equals(HttpStatus.OK)){
-            return ErrorHandler.newHttpError("Trying to PUT a link between the subset Series "+id+" and subset Version "+versionUID+" in LDS failed, with status code "+putLinkRE.getStatusCode(), putLinkRE.getStatusCode(), LoggerFactory.getLogger(LDSFacade.class));
+            return ErrorHandler.newHttpError("Trying to PUT a link between the subset Series "+seriesID+" and subset Version "+versionUID+" in LDS failed, with status code "+putLinkRE.getStatusCode(), putLinkRE.getStatusCode(), LoggerFactory.getLogger(LDSFacade.class));
         }
-        return new ResponseEntity<>(versionJsonNode, HttpStatus.OK);
+        return new ResponseEntity<>(versionJsonNode, HttpStatus.CREATED);
     }
 
     /**
@@ -152,7 +152,7 @@ public class LDSFacade implements LDSInterface {
         if (!Utils.isClean(versionID))
             throw new IllegalArgumentException("versionID must be clean (no special characters except '-' and '_')");
         ResponseEntity<JsonNode> versionRE = new LDSFacade().getVersionByID(versionID);
-        return null;
+        return versionRE;
     }
 
     @Override

--- a/src/main/java/no/ssb/subsetsservice/LDSFacade.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSFacade.java
@@ -87,6 +87,10 @@ public class LDSFacade implements LDSInterface {
         return new LDSConsumer(API_LDS).getFrom(SUBSETS_API+"/"+id).getStatusCode().equals(HttpStatus.OK);
     }
 
+    public boolean existsSubsetSeriesWithID(String id){
+        return new LDSConsumer(API_LDS).getFrom(SERIES_API+"/"+id).getStatusCode().equals(HttpStatus.OK);
+    }
+
     public ResponseEntity<JsonNode> getClassificationSubsetSchema(){
         return new LDSConsumer(API_LDS).getFrom(SUBSETS_API+"/?schema");
     }
@@ -97,6 +101,10 @@ public class LDSFacade implements LDSInterface {
 
     public ResponseEntity<JsonNode> createSubset(JsonNode subset, String id){
         return new LDSConsumer(API_LDS).postTo(SUBSETS_API+"/" + id, subset);
+    }
+
+    public ResponseEntity<JsonNode> createSubsetSeries(JsonNode subset, String id){
+        return new LDSConsumer(API_LDS).putTo(SERIES_API+"/" + id, subset);
     }
 
     public boolean healthReady() {
@@ -150,5 +158,15 @@ public class LDSFacade implements LDSInterface {
     @Override
     public ResponseEntity<JsonNode> getSubsetSeriesSchema() {
         return new LDSConsumer(API_LDS).getFrom(SERIES_API+"/?schema");
+    }
+
+    @Override
+    public void deleteAllSubsetSeries() {
+        //TODO: implement
+    }
+
+    @Override
+    public void deleteSubsetSeries(String id) {
+        //TODO: implement
     }
 }

--- a/src/main/java/no/ssb/subsetsservice/LDSFacade.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSFacade.java
@@ -129,12 +129,12 @@ public class LDSFacade implements LDSInterface {
     public ResponseEntity<JsonNode> putVersionInSeries(String id, String versionID, JsonNode versionJsonNode) {
         String versionUID = id+"_"+versionID;
         ResponseEntity<JsonNode> putVersionRE = new LDSConsumer(API_LDS).putTo(VERSIONS_API+"/"+versionUID, versionJsonNode);
-        if (!putVersionRE.getStatusCode().equals(HttpStatus.OK)){
+        if (!putVersionRE.getStatusCode().equals(HttpStatus.CREATED)){
             return ErrorHandler.newHttpError("Trying to PUT a subset version to LDS failed with status code "+putVersionRE.getStatusCode(), putVersionRE.getStatusCode(), LoggerFactory.getLogger(LDSFacade.class));
         }
         ResponseEntity<JsonNode> putLinkRE = new LDSConsumer(API_LDS).putTo(SERIES_API+"/"+id+"/versions/ClassificationSubsetVersion/"+versionUID, new ObjectMapper().createObjectNode());
         if (!putLinkRE.getStatusCode().equals(HttpStatus.OK)){
-            return ErrorHandler.newHttpError("Trying to PUT a link between the subset Series and subset Version in LDS failed, with status code "+putLinkRE.getStatusCode(), putLinkRE.getStatusCode(), LoggerFactory.getLogger(LDSFacade.class));
+            return ErrorHandler.newHttpError("Trying to PUT a link between the subset Series "+id+" and subset Version "+versionUID+" in LDS failed, with status code "+putLinkRE.getStatusCode(), putLinkRE.getStatusCode(), LoggerFactory.getLogger(LDSFacade.class));
         }
         return new ResponseEntity<>(versionJsonNode, HttpStatus.OK);
     }

--- a/src/main/java/no/ssb/subsetsservice/LDSInterface.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSInterface.java
@@ -82,4 +82,6 @@ public interface LDSInterface {
     ResponseEntity<JsonNode> putVersionInSeries(String id, String versionID, JsonNode versionNode);
 
     ResponseEntity<JsonNode> resolveVersionLink(String versionLink);
+
+    ResponseEntity<JsonNode> getSubsetSeriesSchema();
 }

--- a/src/main/java/no/ssb/subsetsservice/LDSInterface.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSInterface.java
@@ -1,6 +1,7 @@
 package no.ssb.subsetsservice;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 
@@ -67,4 +68,6 @@ public interface LDSInterface {
     boolean healthReady();
 
     void deleteSubset(String url);
+
+    ResponseEntity<JsonNode> editSeries(JsonNode newVersionOfSeries, String seriesID);
 }

--- a/src/main/java/no/ssb/subsetsservice/LDSInterface.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSInterface.java
@@ -84,4 +84,8 @@ public interface LDSInterface {
     ResponseEntity<JsonNode> resolveVersionLink(String versionLink);
 
     ResponseEntity<JsonNode> getSubsetSeriesSchema();
+
+    void deleteAllSubsetSeries();
+
+    void deleteSubsetSeries(String id);
 }

--- a/src/main/java/no/ssb/subsetsservice/LDSInterface.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSInterface.java
@@ -70,4 +70,6 @@ public interface LDSInterface {
     void deleteSubset(String url);
 
     ResponseEntity<JsonNode> editSeries(JsonNode newVersionOfSeries, String seriesID);
+
+    ResponseEntity<JsonNode> putVersionInSeries(String id, String versionID, JsonNode versionNode);
 }

--- a/src/main/java/no/ssb/subsetsservice/LDSInterface.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSInterface.java
@@ -79,7 +79,7 @@ public interface LDSInterface {
 
     ResponseEntity<JsonNode> editSeries(JsonNode newVersionOfSeries, String seriesID);
 
-    ResponseEntity<JsonNode> putVersionInSeries(String id, String versionID, JsonNode versionNode);
+    ResponseEntity<JsonNode> postVersionInSeries(String id, String versionID, JsonNode versionNode);
 
     ResponseEntity<JsonNode> resolveVersionLink(String versionLink);
 

--- a/src/main/java/no/ssb/subsetsservice/LDSInterface.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSInterface.java
@@ -20,6 +20,12 @@ public interface LDSInterface {
      */
     List<String> getAllSubsetIDs() throws HttpClientErrorException;
 
+    ResponseEntity<JsonNode> getVersionByID(String versionId);
+
+    ResponseEntity<JsonNode> getSubsetSeries(String id);
+
+    ResponseEntity<JsonNode> getAllSubsetSeries();
+
     /**
      * GET a list of all the version of each subset that was last UPDATED by the user.
      * This does NOT necessarily return the version with the most recent subsetValidFrom,
@@ -69,7 +75,11 @@ public interface LDSInterface {
 
     void deleteSubset(String url);
 
+    public void deleteAllSubsets();
+
     ResponseEntity<JsonNode> editSeries(JsonNode newVersionOfSeries, String seriesID);
 
     ResponseEntity<JsonNode> putVersionInSeries(String id, String versionID, JsonNode versionNode);
+
+    ResponseEntity<JsonNode> resolveVersionLink(String versionLink);
 }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsController.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsController.java
@@ -439,7 +439,7 @@ public class SubsetsController {
             }
         }
 
-        ResponseEntity<JsonNode> responseEntity = new LDSFacade().createSubset(editableNewVersionOfSubset, id);
+        ResponseEntity<JsonNode> responseEntity = new LDSFacade().editSubset(editableNewVersionOfSubset, id);
         if (responseEntity.getStatusCode().equals(HttpStatus.OK)){
             responseEntity = new ResponseEntity<>(editableNewVersionOfSubset, HttpStatus.OK);
         }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -282,7 +282,7 @@ public class SubsetsControllerV2 {
         return responseEntity;
     }
 
-    @PutMapping(value = "/v2/subsets/{id}/versions", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/v2/subsets/{id}/versions", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<JsonNode> putSubsetVersion(@PathVariable("id") String id, @RequestBody JsonNode version) {
 
         ResponseEntity<JsonNode> getSeriesByIDRE = getSubsetSeriesByID(id);
@@ -292,7 +292,7 @@ public class SubsetsControllerV2 {
         version = null;
 
         //TODO: Validate the 'version' input's validity: Does it contain the right fields with the right values?
-        
+
         String validFrom = editableVersion.get(Field.VALID_FROM).asText();
         String validUntil = editableVersion.has(Field.VALID_UNTIL) && !editableVersion.get(Field.VALID_UNTIL).isNull() ? editableVersion.get(Field.VALID_UNTIL).asText() : null;
         boolean hasValidUntil = validUntil != null;
@@ -329,10 +329,10 @@ public class SubsetsControllerV2 {
         ArrayNode versionJsonNodes = new ObjectMapper().createArrayNode();
         versionLinks.forEach(link -> versionJsonNodes.add(new LDSFacade().resolveVersionLink(link.asText()).getBody()));
         if (!versionLinks.isEmpty()){
-            String firstValidFrom = versionLinks.get(0).get(Field.VALID_FROM).asText();
             JsonNode firstPublishedVersion = versionLinks.get(0);
+            JsonNode lastPublishedVersion = firstPublishedVersion;
+            String firstValidFrom = firstPublishedVersion.get(Field.VALID_FROM).asText();
             String lastValidFrom = firstValidFrom;
-            JsonNode lastPublishedVersion = versionLinks.get(0);
             for (JsonNode versionJsonNode : versionJsonNodes) {
                 if (versionJsonNode.get(Field.ADMINISTRATIVE_STATUS).asText().equals(Field.OPEN)) {
                     String versionValidFrom = versionJsonNode.get(Field.VALID_FROM).asText();

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -325,7 +325,7 @@ public class SubsetsControllerV2 {
         }
 
         if (versionsSize == 0) {
-            new LDSFacade().putVersionInSeries(id, versionID, editableVersion);
+            return new LDSFacade().putVersionInSeries(id, versionID, editableVersion);
         }
 
         ArrayNode versionLinks = series.get(Field.VERSIONS).deepCopy();
@@ -390,7 +390,7 @@ public class SubsetsControllerV2 {
         if (ldsPUT.getStatusCode().equals(HttpStatus.OK))
             return new ResponseEntity<>(editableVersion, HttpStatus.OK);
         else
-            return ldsPUT;
+            return resolveNonOKLDSResponse("PUT version of series with id "+id+" ", ldsPUT);
     }
 
     @GetMapping("/v2/subsets/{id}/versions")

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -406,7 +406,10 @@ public class SubsetsControllerV2 {
             }
             LOG.debug("Done processing and checking new version in relation to old versions");
         }
-        return new ResponseEntity<>("Subset version had no overlap with published versions", OK, LOG);
+        ObjectNode body = new ObjectMapper().createObjectNode();
+        body.put("message", "Subset version had no overlap with published versions");
+        body.put("status", OK.value());
+        return new ResponseEntity<>(body, OK);
     }
 
     @PostMapping(value = "/v2/subsets/{seriesId}/versions", consumes = MediaType.APPLICATION_JSON_VALUE)
@@ -456,60 +459,9 @@ public class SubsetsControllerV2 {
             return ldsPostRE;
         }
 
-        ArrayNode subsetVersionsArray = getVersions(seriesId, true, false).getBody().deepCopy();
-        if (!subsetVersionsArray.isEmpty()){
-            JsonNode firstPublishedVersion = null;
-            JsonNode lastPublishedVersion = null;
-            String firstValidFrom = null;
-            String lastValidFrom = null;
-            for (JsonNode versionJsonNode : subsetVersionsArray) {
-                if (versionJsonNode.get(Field.ADMINISTRATIVE_STATUS).asText().equals(Field.OPEN)) { // We only care about cheching against published subset versions
-                    LOG.debug("Checking version "+versionJsonNode.get(Field.SERIES_ID)+"_"+versionJsonNode.get(Field.VERSION)+" for overlap with the new version, since it is published.");
-                    String versionValidFrom = versionJsonNode.get(Field.VALID_FROM).asText();
-                    if (firstValidFrom == null || versionValidFrom.compareTo(firstValidFrom) < 0)
-                        firstValidFrom = versionValidFrom;
-                    if (lastValidFrom == null || versionValidFrom.compareTo(lastValidFrom) > 0)
-                        lastValidFrom = versionValidFrom;
-                    if (validFrom.compareTo(versionValidFrom) == 0)
-                        return ErrorHandler.newHttpError(
-                                "validFrom can not be the same as existing subset's valid from",
-                                BAD_REQUEST,
-                                LOG);
-                    String versionValidUntil = versionJsonNode.has(Field.VALID_UNTIL) ? versionJsonNode.get(Field.VALID_UNTIL).asText() : null;
-                    if (versionValidUntil != null && hasValidUntil) {
-                        if (validUntil.compareTo(versionValidUntil) <= 0 && validUntil.compareTo(versionValidFrom) >= 0)
-                            return ErrorHandler.newHttpError(
-                                    "The new version's validUntil is within the validity range of an existing subset",
-                                    BAD_REQUEST,
-                                    LOG);
-                        if (validFrom.compareTo(versionValidFrom) >= 0 && validFrom.compareTo(versionValidUntil) <= 0)
-                            return ErrorHandler.newHttpError(
-                                    "The new version's validFrom is within the validity range of an existing subset",
-                                    BAD_REQUEST,
-                                    LOG);
-                        if (validUntil.compareTo(versionValidUntil) == 0)
-                            return ErrorHandler.newHttpError(
-                                    "validUntil can not be the same as existing subset's validUntil, when they are explicit",
-                                    BAD_REQUEST,
-                                    LOG);
-                    }
-                }
-            }
-            LOG.debug("Done iterating over all existing versions of the subset to check validity period overlaps");
-            if (firstValidFrom != null && validFrom.compareTo(firstValidFrom) >= 0 && lastValidFrom != null && validFrom.compareTo(lastValidFrom) <= 0)
-                return ErrorHandler.newHttpError("The validity period of a new subset must be before or after all existing versions", BAD_REQUEST, LOG);
-            boolean isNewLatestVersion = lastValidFrom == null || validFrom.compareTo(lastValidFrom) > 0;
-            boolean isNewFirstVersion = firstValidFrom == null || validFrom.compareTo(firstValidFrom) < 0;
-
-            if (isStatusOpen && versionsSize > 0) {
-                if (isNewLatestVersion) {
-                    //TODO: If OPEN and is new latest version and other versions exist from before, set validUntil of previous version to be == this version's validFrom ?
-                }
-                if (isNewFirstVersion) {
-                    //TODO: If OPEN and is new first version and other versions exist from before, set validUntil of this version to be == validFrom of next version ?
-                }
-            }
-            LOG.debug("Done processing and checking new version in relation to old versions");
+        ResponseEntity<JsonNode> isOverlappingValidityRE = isOverlappingValidity(editableVersion);
+        if (!isOverlappingValidityRE.getStatusCode().is2xxSuccessful()){
+            return isOverlappingValidityRE;
         }
 
         LOG.debug("Attempting to POST version nr "+versionNr+" of subset series "+seriesId+" to LDS");

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -541,7 +541,7 @@ public class SubsetsControllerV2 {
                 String date = Utils.getNowDate();
                 ResponseEntity<JsonNode> codesAtRE = getSubsetCodesAt(id, date, includeFuture, includeDrafts);
                 if (!codesAtRE.getStatusCode().equals(HttpStatus.OK))
-                    return resolveNonOKLDSResponse("get codesAt "+date+" in series with id "+id+" ", versionsByIDRE);
+                    return resolveNonOKLDSResponse("get codesAt "+date+" in series with id "+id+" ", codesAtRE);
                 ArrayNode codes = (ArrayNode) codesAtRE.getBody();
                 return new ResponseEntity<>(codes, HttpStatus.OK);
             }
@@ -624,11 +624,11 @@ public class SubsetsControllerV2 {
         LOG.info("GET codes valid at date "+date+" for subset with id "+id);
 
         if (date != null && Utils.isClean(id) && (Utils.isYearMonthDay(date))){
-            ResponseEntity<JsonNode> versionsResponseEntity = getVersions(id, includeFuture, includeDrafts);
-            if (!versionsResponseEntity.getStatusCode().equals(HttpStatus.OK)){
-                return resolveNonOKLDSResponse("Call for versions of subset with id "+id+" ", versionsResponseEntity);
+            ResponseEntity<JsonNode> versionsRE = getVersions(id, includeFuture, includeDrafts);
+            if (!versionsRE.getStatusCode().equals(HttpStatus.OK)){
+                return resolveNonOKLDSResponse("Call for versions of subset with id "+id+" ", versionsRE);
             }
-            JsonNode versionsResponseBodyJSON = versionsResponseEntity.getBody();
+            JsonNode versionsResponseBodyJSON = versionsRE.getBody();
             if (versionsResponseBodyJSON != null){
                 if (versionsResponseBodyJSON.isArray()) {
                     ArrayNode versionsArrayNode = (ArrayNode) versionsResponseBodyJSON;
@@ -640,6 +640,7 @@ public class SubsetsControllerV2 {
                             return new ResponseEntity<>(codes, HttpStatus.OK);
                         }
                     }
+                    return new ResponseEntity<>(new ObjectMapper().createArrayNode(), HttpStatus.OK);
                 }
                 return ErrorHandler.newHttpError("versions response body was not array", HttpStatus.INTERNAL_SERVER_ERROR, LOG);
             }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -400,7 +400,7 @@ public class SubsetsControllerV2 {
             LOG.debug("Successfully POSTed version nr "+versionNr+" of subset series "+seriesId+" to LDS");
             return new ResponseEntity<>(editableVersion, HttpStatus.CREATED);
         } else
-            return resolveNonOKLDSResponse("PUT version "+versionNr+" of series with id "+seriesId+" ", ldsPostRE);
+            return resolveNonOKLDSResponse("POST version nr "+versionNr+" of series with id "+seriesId+" ", ldsPostRE);
     }
 
     @GetMapping("/v2/subsets/{id}/versions")

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -14,6 +14,7 @@ import java.util.*;
 
 public class Utils {
 
+    public static final String ISO_DATE_PATTERN = "yyyy-MM-dd";
     public static final String ISO_DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss'Z'"; // Quoted "Z" to indicate UTC, no timezone offset
     public static final String CLEAN_ID_REGEX = "^[a-zA-Z0-9-_]+$";
     public static final String YEAR_MONTH_DAY_REGEX = "([12]\\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\\d|3[01]))";
@@ -132,5 +133,12 @@ public class Utils {
 
     public static String generateURN(String classification, String code) {
         return String.format(URN_FORMAT, classification, code);
+    }
+
+    public static String getNowDate() {
+        TimeZone tz = TimeZone.getTimeZone("UTC");
+        DateFormat df = new SimpleDateFormat(ISO_DATE_PATTERN);
+        df.setTimeZone(tz);
+        return df.format(new Date());
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,6 +2,7 @@
 management.endpoints.web.exposure.include=prometheus
 management.endpoints.web.base-path=/
 management.endpoints.web.path-mapping.prometheus=metrics
+springdoc.api-docs.path=/api-docs
 
 # Logging related configurations
 logging.level.no.ssb.subsetsservice=DEBUG


### PR DESCRIPTION
This is the first prototype of the v2 API. I am using the new schemas for SubsetSeries and SubsetVersion.

When creating a series, you first have to POST the series to `v2/subsets` without any subset versions inside it.
To edit the series, PUT `v2/subsets/{seriesID}`. PUT requests to the series can not edit or add versions.
To add a version, POST the version to `v2/subsets/{subsetID}/versions`
To edit a version, use PUT  `v2/subsets/{subsetID}/versions/{versionID}`
If the UID of the subset series is `example`, then use the versionID `example_1` or `1` to retrieve the first version that was added to the series.

This is a zip containing an example series and an example version that I have used for testing:
[v2_subset_series_json.zip](https://github.com/statisticsnorway/klass-subsets-api/files/5414314/v2_subset_series_json.zip)
