### PR TITLE
Basic Hateoas, schema validation, codes have strong link to KLASS codes

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/ErrorHandler.java
+++ b/src/main/java/no/ssb/subsetsservice/ErrorHandler.java
@@ -18,7 +18,7 @@ public class ErrorHandler {
         body.put("error", status.toString());
         body.put("message", message);
         body.put("timestamp", Utils.getNowISO());
-        logger.error(body.toString());
+        logger.error(body.asText());
         return new ResponseEntity<>(body, status);
     }
 
@@ -28,7 +28,7 @@ public class ErrorHandler {
         json.put("exception message", e.getMessage());
         json.put("timestamp", Utils.getNowISO());
         json.put("e.toString", e.toString());
-        logger.error(json.toString());
+        logger.error(json.asText());
     }
 
     public static ResponseEntity<JsonNode> illegalID(Logger logger){

--- a/src/main/java/no/ssb/subsetsservice/Field.java
+++ b/src/main/java/no/ssb/subsetsservice/Field.java
@@ -31,4 +31,6 @@ public class Field {
     public static final String SUBSET_ID = "subsetId";
     public static final String LAST_MODIFIED_BY = "lastModifiedBy";
     public static final String SERIES_ID = "seriesId";
+    public static final String VALID_FROM_IN_REQUESTED_RANGE = "validFromInRequestedRange";
+    public static final String VALID_UNTIL_IN_REQUESTED_RANGE = "validUntilInRequestedRange";
 }

--- a/src/main/java/no/ssb/subsetsservice/Field.java
+++ b/src/main/java/no/ssb/subsetsservice/Field.java
@@ -24,7 +24,7 @@ public class Field {
     public static final String CODE = "code";
     public static final String _LINKS = "_links";
     public static final String SELF = "self";
-    public static final String SUBSET = "subset";
+    public static final String SUBSET = "Subset";
     public static final String CLASSIFICATION_TYPE = "classificationType";
     public static final String VERSIONS = "versions";
     public static final String LAST_MODIFIED = "lastModified";

--- a/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
+++ b/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
@@ -59,25 +59,25 @@ public class KlassURNResolver {
             String URN = code.get(Field.URN).asText();
             String[] urnSplitColon = URN.split(":");
             String classificationID = "";
-            String codeString = "";
+            String codeID = "";
             for (int i1 = 0; i1 < urnSplitColon.length; i1++) {
                 String value = urnSplitColon[i1];
                 if (value.equals("code")){
                     if (urnSplitColon.length > i1+1)
-                        codeString = urnSplitColon[i1+1];
+                        codeID = urnSplitColon[i1+1];
                 } else if (value.equals("classifications")){
                     if (urnSplitColon.length > i1+1)
                         classificationID = urnSplitColon[i1+1];
                 }
             }
             code.put(Field.CLASSIFICATION_ID, classificationID);
-            code.put(Field.CODE, codeString);
-            String selfURL = makeURL(classificationID, fromDate, toDate, codeString);
+            code.put(Field.CODE, codeID);
+            String selfURL = makeKLASSCodesFromToURL(classificationID, fromDate, toDate, codeID);
             ObjectMapper om = new ObjectMapper();
             ObjectNode self = om.createObjectNode().put("href", selfURL);
             ObjectNode links = om.createObjectNode().set(Field.SELF, self);
             code.set(Field._LINKS, links);
-            classificationCodesMap.merge(classificationID, codeString, (c1, c2)-> c1+","+c2);
+            classificationCodesMap.merge(classificationID, codeID, (c1, c2)-> c1+","+c2);
             urnCodeMap.put(URN, code);
         }
 
@@ -87,8 +87,8 @@ public class KlassURNResolver {
         for (Map.Entry<String, String> classificationCodesEntry : classificationCodesMap.entrySet()) {
             String classification = classificationCodesEntry.getKey();
             String codesString = classificationCodesEntry.getValue();
-            String URL = makeURL(classification, fromDate, toDate, codesString);
-            ArrayNode codesFromClassification = (ArrayNode)(getFrom(URL).getBody().get(Field.CODES));
+            String getKlassCodesURL = makeKLASSCodesFromToURL(classification, fromDate, toDate, codesString);
+            ArrayNode codesFromClassification = (ArrayNode)(getFrom(getKlassCodesURL).getBody().get(Field.CODES));
             for (int i = 0; i < codesFromClassification.size(); i++) {
                 JsonNode codeNode = codesFromClassification.get(i);
                 String URN = Utils.generateURN(classification, codeNode.get(Field.CODE).asText());
@@ -104,12 +104,17 @@ public class KlassURNResolver {
         return allCodesArrayNode;
     }
 
-    private String makeURL(String classificationID, String from, String to, String codes){
+    private String makeKLASSCodesFromToURL(String classificationID, String from, String to, String codes){
         KLASS_BASE_URL = getURL();
         return String.format("%s%s/%s/codes.json?from=%s&to=%s&selectCodes=%s", KLASS_BASE_URL, CLASSIFICATIONS_API, classificationID, from, to, codes);
     }
 
-    private ResponseEntity<JsonNode> getFrom(String url)
+    static String makeKLASSClassificationURL(String classificationID){
+        KLASS_BASE_URL = getURL();
+        return String.format("%s%s/%s.json", KLASS_BASE_URL, CLASSIFICATIONS_API, classificationID);
+    }
+
+    static ResponseEntity<JsonNode> getFrom(String url)
     {
         LOG.info("Attempting to GET "+url);
         try {

--- a/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
+++ b/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
@@ -12,7 +12,6 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -114,8 +113,7 @@ public class KlassURNResolver {
         return String.format("%s%s/%s.json", KLASS_BASE_URL, CLASSIFICATIONS_API, classificationID);
     }
 
-    static ResponseEntity<JsonNode> getFrom(String url)
-    {
+    static ResponseEntity<JsonNode> getFrom(String url){
         LOG.info("Attempting to GET "+url);
         try {
             return new RestTemplate().getForEntity(url, JsonNode.class);

--- a/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
+++ b/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
@@ -41,7 +41,13 @@ public class KlassURNResolver {
         LOG.info("Resolving all code URNs in a subset");
 
         ArrayNode codes = (ArrayNode)subset.get(Field.CODES);
-        String from = subset.get(Field.VERSION_VALID_FROM).asText();
+        String from = null;
+        if (subset.has(Field.VALID_FROM))
+            from = subset.get(Field.VALID_FROM).asText();
+        else if (subset.has(Field.VERSION_VALID_FROM))
+            from = subset.get(Field.VERSION_VALID_FROM).asText();
+        else
+            throw new IllegalArgumentException("subset did not contain validFrom or versionValidFrom");
         String fromDate = from.split("T")[0];
         String toDate = to.split("T")[0];
 

--- a/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
@@ -18,6 +18,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
@@ -125,7 +126,13 @@ public class LDSConsumer {
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
         org.springframework.http.HttpEntity<JsonNode> request = new org.springframework.http.HttpEntity<>(json, headers);
         LOG.debug("POSTing to "+fullURLString);
-        ResponseEntity<JsonNode> response = new RestTemplate().postForEntity(fullURLString, request, JsonNode.class);
+        ResponseEntity<JsonNode> response = null;
+        try {
+            response = new RestTemplate().postForEntity(fullURLString, request, JsonNode.class);
+        } catch (HttpClientErrorException e){
+            e.printStackTrace();
+            return ErrorHandler.newHttpError("LDS: Could not POST to "+fullURLString+" because of exception "+e.toString(), e.getStatusCode(), LOG);
+        }
         LOG.debug("POST to "+fullURLString+" - Status: "+response.getStatusCodeValue()+" "+response.getStatusCode().name());
         return response;
     }

--- a/src/main/java/no/ssb/subsetsservice/LDSFacade.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSFacade.java
@@ -172,6 +172,11 @@ public class LDSFacade implements LDSInterface {
     }
 
     @Override
+    public ResponseEntity<JsonNode> getSubsetVersionsSchema() {
+        return new LDSConsumer(API_LDS).getFrom(VERSIONS_API+"/?schema");
+    }
+
+    @Override
     public void deleteAllSubsetSeries() {
         //TODO: implement
     }

--- a/src/main/java/no/ssb/subsetsservice/LDSFacade.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSFacade.java
@@ -137,9 +137,9 @@ public class LDSFacade implements LDSInterface {
         Logger logger = LoggerFactory.getLogger(LDSFacade.class);
         String versionUID = seriesID+"_"+versionNr;
         logger.debug("Attempting to POST version with UID "+versionUID+" to LDS");
-        ResponseEntity<JsonNode> putVersionRE = new LDSConsumer(API_LDS).postTo(VERSIONS_API+"/"+versionUID, versionJsonNode);
-        if (!putVersionRE.getStatusCode().equals(HttpStatus.CREATED)) {
-            return ErrorHandler.newHttpError("Trying to PUT a subset version to LDS failed with status code "+putVersionRE.getStatusCode(), putVersionRE.getStatusCode(), logger);
+        ResponseEntity<JsonNode> postVersionRE = new LDSConsumer(API_LDS).postTo(VERSIONS_API+"/"+versionUID, versionJsonNode);
+        if (!postVersionRE.getStatusCode().equals(HttpStatus.CREATED)) {
+            return postVersionRE;
         }
         logger.debug("Attempting to PUT link from series with seriesID "+seriesID+" to version with UID "+versionUID+" to LDS");
         ResponseEntity<JsonNode> putLinkRE = new LDSConsumer(API_LDS).putTo(SERIES_API+"/"+seriesID+"/versions/ClassificationSubsetVersion/"+versionUID, new ObjectMapper().createObjectNode());

--- a/src/main/java/no/ssb/subsetsservice/LDSFacade.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSFacade.java
@@ -167,13 +167,28 @@ public class LDSFacade implements LDSInterface {
     }
 
     @Override
+    public ResponseEntity<JsonNode> getSubsetSeriesDefinition() {
+        ResponseEntity<JsonNode> versionSchemaRE = new LDSConsumer(API_LDS).getFrom(SERIES_API+"/?schema");
+        if (!versionSchemaRE.getStatusCode().is2xxSuccessful()){
+            return versionSchemaRE;
+        }
+        JsonNode definition = versionSchemaRE.getBody().get("definitions").get("ClassificationSubsetSeries");
+        return new ResponseEntity<>(definition, HttpStatus.OK);
+    }
+
+    @Override
     public ResponseEntity<JsonNode> getSubsetSeriesSchema() {
         return new LDSConsumer(API_LDS).getFrom(SERIES_API+"/?schema");
     }
 
     @Override
-    public ResponseEntity<JsonNode> getSubsetVersionsSchema() {
-        return new LDSConsumer(API_LDS).getFrom(VERSIONS_API+"/?schema");
+    public ResponseEntity<JsonNode> getSubsetVersionsDefinition() {
+        ResponseEntity<JsonNode> versionSchemaRE = new LDSConsumer(API_LDS).getFrom(VERSIONS_API+"/?schema");
+        if (!versionSchemaRE.getStatusCode().is2xxSuccessful()){
+            return versionSchemaRE;
+        }
+        JsonNode definition = versionSchemaRE.getBody().get("definitions").get("ClassificationSubsetVersion");
+        return new ResponseEntity<>(definition, HttpStatus.OK);
     }
 
     @Override

--- a/src/main/java/no/ssb/subsetsservice/LDSInterface.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSInterface.java
@@ -85,6 +85,8 @@ public interface LDSInterface {
 
     ResponseEntity<JsonNode> getSubsetSeriesSchema();
 
+    ResponseEntity<JsonNode> getSubsetVersionsSchema();
+
     void deleteAllSubsetSeries();
 
     void deleteSubsetSeries(String id);

--- a/src/main/java/no/ssb/subsetsservice/LDSInterface.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSInterface.java
@@ -83,9 +83,11 @@ public interface LDSInterface {
 
     ResponseEntity<JsonNode> resolveVersionLink(String versionLink);
 
+    ResponseEntity<JsonNode> getSubsetSeriesDefinition();
+
     ResponseEntity<JsonNode> getSubsetSeriesSchema();
 
-    ResponseEntity<JsonNode> getSubsetVersionsSchema();
+    ResponseEntity<JsonNode> getSubsetVersionsDefinition();
 
     void deleteAllSubsetSeries();
 

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -750,7 +750,7 @@ public class SubsetsControllerV2 {
             String versionPath = version.asText(); // should be "/ClassificationSubsetVersion/{version_id}", since this is how LDS links a resource of a different type
             String[] splitBySlash = versionPath.split("/");
             assert splitBySlash[0].isBlank() : "Index 0 in the array that splits the versionPath by '/' is not blank";
-            assert splitBySlash[1].equals("ClassificationSubsetVersion") : "Index 1 in the array that splits the versionPath by '/' is not 'ClassificationSubsetVersion'"; //TODO: these checks should be removed later when i know it works
+            assert splitBySlash[1].equals("ClassificationSubsetVersion") : "Index 1 in the array that splits the versionPath by '/' is not 'ClassificationSubsetVersion'"; //TODO: these checks could be removed later when i know it works
             String versionUID = splitBySlash[2];
             newVersions.add(Utils.getVersionLink(seriesUID, versionUID));
         }

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -177,7 +177,7 @@ public class Utils {
         return String.format(URN_FORMAT_VALID_FROM_ENCODED_NAME, classification, code, versionValidFrom, encodedName);
     }
 
-    public static JsonNode addCodeVersion(JsonNode code) throws Exception {
+    public static JsonNode addCodeVersionAndValidFrom(JsonNode code) throws Exception {
         String validFromInRequestedRange = code.get("validFromInRequestedRange").asText();
         String classificationID = code.get(Field.CLASSIFICATION_ID).asText();
         ResponseEntity<JsonNode> classificationJsonNodeRE = KlassURNResolver.getFrom(KlassURNResolver.makeKLASSClassificationURL(classificationID));
@@ -191,6 +191,7 @@ public class Utils {
                     String codeVersionURL = classificationVersion.get(Field._LINKS).get(Field.SELF).get("href").asText();
                     ObjectNode editableCode = code.deepCopy();
                     editableCode.put(Field.VERSION, codeVersionURL);
+                    editableCode.put(Field.VALID_FROM, classificationVersionValidFrom);
                     return editableCode;
                 }
             }


### PR DESCRIPTION
## Validation
We now validate on POST and PUT of Series and Versions whether _only_ fields that are defined in the schema are present. We also validate that all required fields are present before sending to LDS.

## HATEOAS
Series now have a link to self. `"_links":{ "self":{"href":"/v2/subsets/{seriesId}"} }`
Versions now have a link to self. `"_links":{ "self":{"href":"/v2/subsets/{seriesId}/versions/{versionId}"} }`
For now I wanted the links to be independent of the server address. We can discuss this.
The list of Versions in a Series contain the same links as the versions have to themselves.

## Strong 1-to-1 connection to KLASS codes
Codes now have a pointer to the classification version they belong to: `"version": "https://data.ssb.no/api/klass/v1/versions/473"`. I chose to include the whole URL to the classification version just to make sure it's explicit that this is not "our" version of the code, it is the version of the classification the code belongs to. The link to the versions is found by using the `validFromInRequestedRange` at the time the Version is submitted to find which version at the time has a validity period that contains that date. Calculating which version the selected code belongs to at the time of submission gives us a theoretically unbreakable 1-to-1 connection between our stored code and the equivalent KLASS code. This means we have a specific validFrom and validUntil that is not dependent on the `valid[....]InRequestedRange` values. **EDIT:** The validFrom of a classification version should never change, and is probably relevant to most people, so I store that in the code as well so we can avoid users making excessive calls to the KLASS API to find the validity dates for the codes by GETing the classification versions.

## Schema changes required

In order for these changes to work, we should change the LDS schema again: 
- The schema for a Code should allow for the link to the classification version it comes from (and maybe also the validFrom date, for convenience). I hope that's all right!