### PR TITLE
DELETE mappings, and misc.

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/Field.java
+++ b/src/main/java/no/ssb/subsetsservice/Field.java
@@ -33,4 +33,5 @@ public class Field {
     public static final String SERIES_ID = "seriesId";
     public static final String VALID_FROM_IN_REQUESTED_RANGE = "validFromInRequestedRange";
     public static final String VALID_UNTIL_IN_REQUESTED_RANGE = "validUntilInRequestedRange";
+    public static final String STATISTICAL_UNITS = "statisticalUnits";
 }

--- a/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
@@ -87,14 +87,16 @@ public class LDSConsumer {
         // Because Spring RestTemplate fails when the response is too long, I use Apache Commons Http Client instead,
         // and pack the response into a ResponseEntity, so it feels like Spring to the user.
         // I could not get Spring WebClient to work, which would have been my first choice.
+        String urlString = LDS_URL + additional;
+        LOG.debug("GET from "+urlString);
         CloseableHttpClient httpclient = HttpClients.createDefault();
-        HttpGet httpGet = new HttpGet(LDS_URL + additional);
+        HttpGet httpGet = new HttpGet(urlString);
         CloseableHttpResponse response1 = null;
         try {
             try {
                 response1 = httpclient.execute(httpGet);
             } catch (ConnectException e){
-                return ErrorHandler.newHttpError("Could not retrieve "+LDS_URL+additional+" because of a ConnectException: "+e.toString(), HttpStatus.FAILED_DEPENDENCY, LOG);
+                return ErrorHandler.newHttpError("Could not retrieve "+urlString+" because of a ConnectException: "+e.toString(), HttpStatus.FAILED_DEPENDENCY, LOG);
             }
             System.out.println(response1.getStatusLine());
             System.out.println(response1.toString());
@@ -107,7 +109,7 @@ public class LDSConsumer {
             return responseEntity;
         } catch (Exception e) {
             e.printStackTrace();
-            return ErrorHandler.newHttpError("Could not retrieve "+LDS_URL+additional+" because of an exception: "+e.toString(), HttpStatus.INTERNAL_SERVER_ERROR, LOG);
+            return ErrorHandler.newHttpError("Could not retrieve "+urlString+" because of an exception: "+e.toString(), HttpStatus.INTERNAL_SERVER_ERROR, LOG);
         } finally {
             try {
                 if (response1 != null)
@@ -120,12 +122,11 @@ public class LDSConsumer {
 
     ResponseEntity<JsonNode> postTo(String additional, JsonNode json){
         String fullURLString = LDS_URL+additional;
-        LOG.debug("Building request for POSTing to "+fullURLString);
+        LOG.debug("POST to "+fullURLString);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
         org.springframework.http.HttpEntity<JsonNode> request = new org.springframework.http.HttpEntity<>(json, headers);
-        LOG.debug("POSTing to "+fullURLString);
         ResponseEntity<JsonNode> response = null;
         try {
             response = new RestTemplate().postForEntity(fullURLString, request, JsonNode.class);
@@ -146,8 +147,10 @@ public class LDSConsumer {
      * @return
      */
     ResponseEntity<JsonNode> putTo(String additional, JsonNode json){
+        String urlString = LDS_URL+additional;
+        LOG.debug("PUT to "+urlString);
         CloseableHttpClient httpclient = HttpClients.createDefault();
-        HttpPut httpPut = new HttpPut(LDS_URL+additional);
+        HttpPut httpPut = new HttpPut(urlString);
         httpPut.setHeader("Accept", "application/json");
         httpPut.setHeader("Content-type", "application/json");
         StringEntity stringEntity = null;
@@ -166,7 +169,7 @@ public class LDSConsumer {
             HttpEntity entity = response.getEntity();
             int status = response.getStatusLine().getStatusCode();
             HttpStatus httpStatus = HttpStatus.resolve(status);
-            LOG.debug("PUT to "+LDS_URL+additional+" - Status: "+httpStatus.toString());
+            LOG.debug("PUT to "+urlString+" - Status: "+httpStatus.toString());
             if (!httpStatus.equals(HttpStatus.CREATED) && !httpStatus.equals(HttpStatus.OK)){
                 String responseBodyString = EntityUtils.toString(entity);
                 return ErrorHandler.newHttpError(

--- a/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
@@ -94,7 +94,7 @@ public class LDSConsumer {
             try {
                 response1 = httpclient.execute(httpGet);
             } catch (ConnectException e){
-                return ErrorHandler.newHttpError("Could not retrieve "+LDS_URL+additional+" because of an exception: "+e.toString(), HttpStatus.INTERNAL_SERVER_ERROR, LOG);
+                return ErrorHandler.newHttpError("Could not retrieve "+LDS_URL+additional+" because of a ConnectException: "+e.toString(), HttpStatus.FAILED_DEPENDENCY, LOG);
             }
             System.out.println(response1.getStatusLine());
             System.out.println(response1.toString());

--- a/src/main/java/no/ssb/subsetsservice/LDSFacade.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSFacade.java
@@ -12,6 +12,8 @@ import org.springframework.web.client.HttpClientErrorException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.springframework.http.HttpStatus.OK;
+
 public class LDSFacade implements LDSInterface {
 
     String API_LDS = "";
@@ -29,7 +31,7 @@ public class LDSFacade implements LDSInterface {
 
         ResponseEntity<JsonNode> allSubsetsRE = getLastUpdatedVersionOfAllSubsets();
 
-        if (allSubsetsRE.getStatusCode().equals(HttpStatus.OK)) {
+        if (allSubsetsRE.getStatusCode().equals(OK)) {
             JsonNode ldsREBody = allSubsetsRE.getBody();
             if (ldsREBody != null) {
                 if (ldsREBody.isArray()) {
@@ -56,7 +58,7 @@ public class LDSFacade implements LDSInterface {
             String versionID = version.get("_links").get("self").get("href").asText();
         }
         */
-        return new ResponseEntity<>(versionArrayNode, HttpStatus.OK);
+        return new ResponseEntity<>(versionArrayNode, OK);
     }
 
     /**
@@ -85,11 +87,11 @@ public class LDSFacade implements LDSInterface {
     }
 
     public boolean existsSubsetWithID(String id){
-        return new LDSConsumer(API_LDS).getFrom(SUBSETS_API+"/"+id).getStatusCode().equals(HttpStatus.OK);
+        return new LDSConsumer(API_LDS).getFrom(SUBSETS_API+"/"+id).getStatusCode().equals(OK);
     }
 
     public boolean existsSubsetSeriesWithID(String id){
-        return new LDSConsumer(API_LDS).getFrom(SERIES_API+"/"+id).getStatusCode().equals(HttpStatus.OK);
+        return new LDSConsumer(API_LDS).getFrom(SERIES_API+"/"+id).getStatusCode().equals(OK);
     }
 
     public ResponseEntity<JsonNode> getClassificationSubsetSchema(){
@@ -100,7 +102,7 @@ public class LDSFacade implements LDSInterface {
         ResponseEntity<JsonNode> postRE = new LDSConsumer(API_LDS).postTo(SUBSETS_API+"/" + id, subset);
         HttpStatus status = postRE.getStatusCode();
         if (status.is2xxSuccessful())
-            status = HttpStatus.OK;
+            status = OK;
         if (postRE.hasBody())
             return new ResponseEntity<>(postRE.getBody(), postRE.getHeaders(), status);
         return new ResponseEntity<>(postRE.getHeaders(), status);
@@ -115,12 +117,12 @@ public class LDSFacade implements LDSInterface {
     }
 
     public boolean healthReady() {
-        return new LDSConsumer(API_LDS).getFrom("/health/ready").getStatusCode().equals(HttpStatus.OK);
+        return new LDSConsumer(API_LDS).getFrom("/health/ready").getStatusCode().equals(OK);
     }
 
     public void deleteSubset(String id) {
         String url = SUBSETS_API+"/"+id;
-       new LDSConsumer(API_LDS).delete(url);
+        new LDSConsumer(API_LDS).delete(url);
     }
 
     public ResponseEntity<JsonNode> editSeries(JsonNode series, String id) {
@@ -143,7 +145,7 @@ public class LDSFacade implements LDSInterface {
         }
         logger.debug("Attempting to PUT link from series with seriesID "+seriesID+" to version with UID "+versionUID+" to LDS");
         ResponseEntity<JsonNode> putLinkRE = new LDSConsumer(API_LDS).putTo(SERIES_API+"/"+seriesID+"/versions/ClassificationSubsetVersion/"+versionUID, new ObjectMapper().createObjectNode());
-        if (!putLinkRE.getStatusCode().equals(HttpStatus.OK)) {
+        if (!putLinkRE.getStatusCode().equals(OK)) {
             return ErrorHandler.newHttpError("Trying to PUT a link between the subset Series "+seriesID+" and subset Version "+versionUID+" in LDS failed, with status code "+putLinkRE.getStatusCode(), putLinkRE.getStatusCode(), logger);
         }
         logger.debug("Successfully posted and linked version with UID "+versionUID+" to subset series with id "+seriesID);
@@ -173,7 +175,7 @@ public class LDSFacade implements LDSInterface {
             return versionSchemaRE;
         }
         JsonNode definition = versionSchemaRE.getBody().get("definitions").get("ClassificationSubsetSeries");
-        return new ResponseEntity<>(definition, HttpStatus.OK);
+        return new ResponseEntity<>(definition, OK);
     }
 
     @Override
@@ -188,16 +190,31 @@ public class LDSFacade implements LDSInterface {
             return versionSchemaRE;
         }
         JsonNode definition = versionSchemaRE.getBody().get("definitions").get("ClassificationSubsetVersion");
-        return new ResponseEntity<>(definition, HttpStatus.OK);
+        return new ResponseEntity<>(definition, OK);
     }
 
     @Override
-    public void deleteAllSubsetSeries() {
-        //TODO: implement
+    public ResponseEntity<JsonNode> deleteAllSubsetSeries() {
+        ResponseEntity<JsonNode> getAllRE = getAllSubsetSeries();
+        ArrayNode allSeriesArrayNode = (ArrayNode) getAllRE.getBody();
+        for (JsonNode series : allSeriesArrayNode){
+            String id = series.get(Field.ID).asText();
+            deleteSubsetSeries(id);
+        }
+        return new ResponseEntity<>(OK);
     }
 
     @Override
-    public void deleteSubsetSeries(String id) {
-        //TODO: implement
+    public ResponseEntity<JsonNode> deleteSubsetSeries(String id) {
+        ResponseEntity<JsonNode> getSeriesRE = getSubsetSeries(id);
+        ArrayNode versionsArrayNode = (ArrayNode)getSeriesRE.getBody().get(Field.VERSIONS);
+        for(JsonNode versionLink : versionsArrayNode){
+            String[] splitSlash = versionLink.asText().split("/");
+            String versionUID = splitSlash[splitSlash.length-1];
+            new LDSConsumer(API_LDS).delete(VERSIONS_API+"/"+versionUID);
+        }
+        String url = SERIES_API+"/"+id;
+        new LDSConsumer(API_LDS).delete(url);
+        return new ResponseEntity<>(OK);
     }
 }

--- a/src/main/java/no/ssb/subsetsservice/LDSInterface.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSInterface.java
@@ -1,7 +1,6 @@
 package no.ssb.subsetsservice;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 
@@ -89,7 +88,7 @@ public interface LDSInterface {
 
     ResponseEntity<JsonNode> getSubsetVersionsDefinition();
 
-    void deleteAllSubsetSeries();
+    ResponseEntity<JsonNode> deleteAllSubsetSeries();
 
-    void deleteSubsetSeries(String id);
+    ResponseEntity<JsonNode> deleteSubsetSeries(String id);
 }

--- a/src/main/java/no/ssb/subsetsservice/LDSInterface.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSInterface.java
@@ -91,4 +91,5 @@ public interface LDSInterface {
     ResponseEntity<JsonNode> deleteAllSubsetSeries();
 
     ResponseEntity<JsonNode> deleteSubsetSeries(String id);
+    void deleteSubsetVersion(String id, String versionUid);
 }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -154,7 +154,7 @@ public class SubsetsControllerV2 {
      * @return
      */
     @PutMapping(value = "/v2/subsets/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<JsonNode> putSubset(@PathVariable("id") String seriesId, @RequestBody JsonNode newVersionOfSeries) {
+    public ResponseEntity<JsonNode> putSubsetSeries(@PathVariable("id") String seriesId, @RequestBody JsonNode newVersionOfSeries) {
         metricsService.incrementPUTCounter();
         LOG.info("PUT subset series with id "+seriesId);
 
@@ -368,7 +368,7 @@ public class SubsetsControllerV2 {
     }
 
     @PostMapping(value = "/v2/subsets/{seriesId}/versions", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<JsonNode> putSubsetVersion(@PathVariable("seriesId") String seriesId, @RequestBody JsonNode version) {
+    public ResponseEntity<JsonNode> postSubsetVersion(@PathVariable("seriesId") String seriesId, @RequestBody JsonNode version) {
         if (!Utils.isClean(seriesId))
             return ErrorHandler.illegalID(LOG);
 

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -134,13 +134,12 @@ public class SubsetsControllerV2 {
 
         ResponseEntity<JsonNode> subsetSeriesByIDRE = new LDSFacade().getSubsetSeries(id);
         HttpStatus status = subsetSeriesByIDRE.getStatusCode();
+        LOG.debug("Call to LDSFacade to get a subset series with id "+id+" returned "+status.toString());
         if (status.equals(OK)) {
             JsonNode series = addLinksToSeries(subsetSeriesByIDRE.getBody());
             return new ResponseEntity<>(series, OK);
-        } else if (status.equals(NOT_FOUND)){
-            return ErrorHandler.newHttpError("Subset series with id "+id+" was not found", NOT_FOUND, LOG);
-        }
-        return resolveNonOKLDSResponse("GET subsetSeries w id '"+id+"'", subsetSeriesByIDRE);
+        } else
+            return subsetSeriesByIDRE;
     }
 
     /**

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -173,9 +173,11 @@ public class SubsetsControllerV2 {
             return resolveNonOKLDSResponse("GET subsetSeries w id '"+seriesId+"'", getSeriesRE);
         }
 
-        JsonNode currentLatestEditionOfSeries = getSeriesRE.getBody();
+        ObjectNode currentLatestEditionOfSeries = getSeriesRE.getBody().deepCopy();
+        currentLatestEditionOfSeries.remove(Field._LINKS);
         ObjectNode editableNewVersionOfSeries = newVersionOfSeries.deepCopy();
         newVersionOfSeries = null;
+        editableNewVersionOfSeries.remove(Field._LINKS);
 
         ArrayNode oldVersionsArray = currentLatestEditionOfSeries.has(Field.VERSIONS) ? currentLatestEditionOfSeries.get(Field.VERSIONS).deepCopy() : new ObjectMapper().createArrayNode();
         editableNewVersionOfSeries.set(Field.VERSIONS, oldVersionsArray);

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -695,11 +695,12 @@ public class SubsetsControllerV2 {
         return new LDSFacade().getSubsetSeriesSchema();
     }
 
+    @DeleteMapping("/v2/subsets")
     void deleteAllSeries(){
         new LDSFacade().deleteAllSubsetSeries();
     }
-
-    void deleteSeriesById(String id){
+    @DeleteMapping("/v2/subsets/{id}")
+    void deleteSeriesById(@PathVariable("id") String id){
         new LDSFacade().deleteSubsetSeries(id);
     }
 

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -637,6 +637,16 @@ public class SubsetsControllerV2 {
         new LDSFacade().deleteSubsetSeries(id);
     }
 
+    @DeleteMapping("/v2/subsets/{id}/versions/{versionId}")
+    void deleteSeriesById(@PathVariable("id") String id, @PathVariable("versionId") String versionId){
+        //Delete version from LDS
+        String[] versionIdSplitUnderscore = versionId.split("_");
+        if (versionIdSplitUnderscore.length > 1)
+            new LDSFacade().deleteSubsetVersion(id, versionId);
+        else
+            new LDSFacade().deleteSubsetVersion(id, id+"_"+versionId);
+    }
+
     ResponseEntity<JsonNode> validateVersion(JsonNode version){
         String versionNr = version.has(Field.VERSION) ? version.get(Field.VERSION).asText() : "with no version nr";
         String seriesID = version.has(Field.SERIES_ID) ? version.get(Field.SERIES_ID).asText() : "";

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -368,9 +368,8 @@ public class SubsetsControllerV2 {
         metricsService.incrementGETCounter();
         LOG.info("GET all versions of subset with id: "+id+" includeFuture: "+includeFuture+" includeDrafts: "+includeDrafts);
 
-        if (!Utils.isClean(id)){
+        if (!Utils.isClean(id))
             return ErrorHandler.illegalID(LOG);
-        }
 
         ResponseEntity<JsonNode> getSeriesByIDRE = getSubsetSeriesByID(id);
         if (!getSeriesByIDRE.getStatusCode().equals(OK))
@@ -433,8 +432,10 @@ public class SubsetsControllerV2 {
         }
         ResponseEntity<JsonNode> versionRE = new LDSFacade().getVersionByID(versionID);
         HttpStatus status = versionRE.getStatusCode();
+        if (status.equals(NOT_FOUND))
+            return versionRE;
         if (!status.is2xxSuccessful())
-            return resolveNonOKLDSResponse("GET version by id '"+versionID+"' ", versionRE);
+            return resolveNonOKLDSResponse("GET version of series '"+seriesID+"' from LDS by versionId '"+versionID+"' ", versionRE);
         JsonNode versionJsonNode = versionRE.getBody();
         versionJsonNode = Utils.addLinksToSubsetVersion(versionJsonNode);
         return new ResponseEntity<>(versionJsonNode, OK);
@@ -480,16 +481,13 @@ public class SubsetsControllerV2 {
         LOG.info("GET codes of subset with id "+id);
         metricsService.incrementGETCounter();
 
-        if (!Utils.isClean(id)) {
+        if (!Utils.isClean(id))
             return ErrorHandler.illegalID(LOG);
-        }
 
-        boolean isFromDate = from != null;
         boolean isToDate = to != null;
-
-        if ((isFromDate && ! Utils.isYearMonthDay(from)) || (isToDate && ! Utils.isYearMonthDay(to))){
-            return ErrorHandler.newHttpError("'from' and 'to' need to be dates on the form 'yyyy-MM-dd'", BAD_REQUEST, LOG);
-        }
+        boolean isFromDate = from != null;
+        if ((isFromDate && !Utils.isYearMonthDay(from)) || (isToDate && !Utils.isYearMonthDay(to)))
+            return ErrorHandler.newHttpError("'from' and 'to' must be on format 'YYYY-MM-DD'", BAD_REQUEST, LOG);
 
         if (!isFromDate && !isToDate) {
             LOG.debug("getting all codes of the latest/current version of subset "+id);
@@ -497,15 +495,17 @@ public class SubsetsControllerV2 {
             JsonNode responseBodyJSON = versionsByIDRE.getBody();
             if (!versionsByIDRE.getStatusCode().equals(OK))
                 return resolveNonOKLDSResponse("get versions of series with id "+id+" ", versionsByIDRE);
-            else if (responseBodyJSON != null){
+            else {
+                if (responseBodyJSON == null) {
+                    return ErrorHandler.newHttpError("response body of getSubset with id " + id + " was null, so could not get codes.", INTERNAL_SERVER_ERROR, LOG);
+                }
                 String date = Utils.getNowDate();
                 ResponseEntity<JsonNode> codesAtRE = getSubsetCodesAt(id, date, includeFuture, includeDrafts);
                 if (!codesAtRE.getStatusCode().equals(OK))
-                    return resolveNonOKLDSResponse("get codesAt "+date+" in series with id "+id+" ", codesAtRE);
+                    return resolveNonOKLDSResponse("GET codesAt "+date+" in series with id "+id+" ", codesAtRE);
                 ArrayNode codes = (ArrayNode) codesAtRE.getBody();
                 return new ResponseEntity<>(codes, OK);
             }
-            return ErrorHandler.newHttpError("response body of getSubset with id "+id+" was null, so could not get codes.", INTERNAL_SERVER_ERROR, LOG);
         }
 
         // If a date interval is specified using 'from' and 'to' query parameters
@@ -516,56 +516,55 @@ public class SubsetsControllerV2 {
         LOG.debug(String.format("Getting valid codes of subset %s from date %s to date %s", id, from, to));
         ObjectMapper mapper = new ObjectMapper();
         Map<String, Integer> codeMap = new HashMap<>();
-        int nrOfVersions;
-        if (versionsResponseBodyJson == null) {
+
+        if (versionsResponseBodyJson == null)
             return ErrorHandler.newHttpError("Response body was null", INTERNAL_SERVER_ERROR, LOG);
+        if (!versionsResponseBodyJson.isArray())
+            return ErrorHandler.newHttpError("Response body was null", INTERNAL_SERVER_ERROR, LOG);
+
+        ArrayNode versionsValidInDateRange = (ArrayNode) versionsResponseBodyJson;
+        int nrOfVersions = versionsValidInDateRange.size();
+        LOG.debug("Nr of versions: " + nrOfVersions);
+
+        for (int i = versionsValidInDateRange.size() - 1; i >= 0; i--) {
+            JsonNode version = versionsValidInDateRange.get(i);
+            if (!includeDrafts && !version.get(Field.ADMINISTRATIVE_STATUS).asText().equals(Field.OPEN)) {
+                versionsValidInDateRange.remove(i);
+            }
+            if (isToDate && version.get(Field.VALID_FROM).asText().compareTo(to) > 0) {
+                versionsValidInDateRange.remove(i);
+            }
+            if (isFromDate && version.has(Field.VALID_UNTIL) && version.get(Field.VALID_UNTIL).asText().compareTo(from) < 0) {
+                versionsValidInDateRange.remove(i);
+            }
         }
-        if (versionsResponseBodyJson.isArray()) {
-            ArrayNode versionsValidInDateRange = (ArrayNode) versionsResponseBodyJson;
-            nrOfVersions = versionsValidInDateRange.size();
-            LOG.debug("Nr of versions: " + nrOfVersions);
 
-            for (int i = versionsValidInDateRange.size() - 1; i >= 0; i--) {
-                JsonNode version = versionsValidInDateRange.get(i);
-                if (!includeDrafts && !version.get(Field.ADMINISTRATIVE_STATUS).asText().equals(Field.OPEN)) {
-                    versionsValidInDateRange.remove(i);
-                }
-                if (isToDate && version.get(Field.VALID_FROM).asText().compareTo(to) > 0) {
-                    versionsValidInDateRange.remove(i);
-                }
-                if (isFromDate && version.has(Field.VALID_UNTIL) && version.get(Field.VALID_UNTIL).asText().compareTo(from) < 0) {
-                    versionsValidInDateRange.remove(i);
-                }
+        // Check if first version includes fromDate, and last version includes toDate. If not, then return an empty list.
+
+        for (JsonNode subsetVersion : versionsValidInDateRange) {
+            LOG.debug("Version " + subsetVersion.get(Field.VERSION) + " is valid in the interval, so codes will be added to map");
+            // . . . using each code in this version as key, increment corresponding integer value in map
+            JsonNode codes = subsetVersion.get(Field.CODES);
+            ArrayNode codesArrayNode = (ArrayNode) codes;
+            LOG.debug("There are " + codesArrayNode.size() + " codes in this version");
+            for (JsonNode jsonNode : codesArrayNode) {
+                String codeURN = jsonNode.get(Field.URN).asText();
+                codeMap.merge(codeURN, 1, Integer::sum);
             }
-
-            // Check if first version includes fromDate, and last version includes toDate. If not, then return an empty list.
-
-            for (JsonNode subsetVersion : versionsValidInDateRange) {
-                LOG.debug("Version " + subsetVersion.get(Field.VERSION) + " is valid in the interval, so codes will be added to map");
-                // . . . using each code in this version as key, increment corresponding integer value in map
-                JsonNode codes = subsetVersion.get(Field.CODES);
-                ArrayNode codesArrayNode = (ArrayNode) codes;
-                LOG.debug("There are " + codesArrayNode.size() + " codes in this version");
-                for (JsonNode jsonNode : codesArrayNode) {
-                    String codeURN = jsonNode.get(Field.URN).asText();
-                    codeMap.merge(codeURN, 1, Integer::sum);
-                }
-            }
-
-            ArrayNode intersectionValidCodesInIntervalArrayNode = mapper.createArrayNode();
-
-            // Only return codes that were in every version in the interval, (=> they were always valid)
-            for (String key : codeMap.keySet()) {
-                int value = codeMap.get(key);
-                LOG.trace("key:" + key + " value:" + value);
-                if (value == nrOfVersions)
-                    intersectionValidCodesInIntervalArrayNode.add(key);
-            }
-
-            LOG.debug("nr of valid codes: " + intersectionValidCodesInIntervalArrayNode.size());
-            return new ResponseEntity<>(intersectionValidCodesInIntervalArrayNode, OK);
         }
-        return ErrorHandler.newHttpError("Response body was null", INTERNAL_SERVER_ERROR, LOG);
+
+        ArrayNode intersectionValidCodesInIntervalArrayNode = mapper.createArrayNode();
+
+        // Only return codes that were in every version in the interval, (=> they were always valid)
+        for (String key : codeMap.keySet()) {
+            int value = codeMap.get(key);
+            LOG.trace("key:" + key + " value:" + value);
+            if (value == nrOfVersions)
+                intersectionValidCodesInIntervalArrayNode.add(key);
+        }
+
+        LOG.debug("nr of valid codes: " + intersectionValidCodesInIntervalArrayNode.size());
+        return new ResponseEntity<>(intersectionValidCodesInIntervalArrayNode, OK);
     }
 
     /**
@@ -581,44 +580,45 @@ public class SubsetsControllerV2 {
                                                      @RequestParam(defaultValue = "false") boolean includeFuture,
                                                      @RequestParam(defaultValue = "false") boolean includeDrafts) {
         metricsService.incrementGETCounter();
-        LOG.info("GET codes valid at date "+date+" for subset with id "+id);
+        LOG.info("GET codesAt (valid at date) "+date+" for subset with id "+id);
 
-        if (date != null && Utils.isClean(id) && (Utils.isYearMonthDay(date))){
-            ResponseEntity<JsonNode> versionsRE = getVersions(id, includeFuture, includeDrafts);
-            if (!versionsRE.getStatusCode().equals(OK)){
-                return resolveNonOKLDSResponse("Call for versions of subset with id "+id+" ", versionsRE);
+        if (date == null || !Utils.isClean(id) || (!Utils.isYearMonthDay(date))) {
+            StringBuilder stringBuilder = new StringBuilder();
+            if (date == null) {
+                stringBuilder.append("date == null. ");
+            } else if (!Utils.isYearMonthDay(date)) {
+                stringBuilder.append("date ").append(date).append(" was wrong format");
             }
-            JsonNode versionsResponseBodyJSON = versionsRE.getBody();
-            if (versionsResponseBodyJSON != null){
-                if (versionsResponseBodyJSON.isArray()) {
-                    ArrayNode versionsArrayNode = (ArrayNode) versionsResponseBodyJSON;
-                    for (JsonNode versionJsonNode : versionsArrayNode) {
-                        String entryValidFrom = versionJsonNode.get(Field.VALID_FROM).textValue();
-                        String entryValidUntil = versionJsonNode.has(Field.VALID_UNTIL) ? versionJsonNode.get(Field.VALID_UNTIL).textValue() : null;
-                        if (entryValidFrom.compareTo(date) <= 0 && (entryValidUntil == null || entryValidUntil.compareTo(date) >= 0) ){
-                            JsonNode codes = versionJsonNode.get(Field.CODES);
-                            return new ResponseEntity<>(codes, OK);
-                        }
-                    }
-                    return new ResponseEntity<>(new ObjectMapper().createArrayNode(), OK);
-                }
-                return ErrorHandler.newHttpError("versions response body was not array", INTERNAL_SERVER_ERROR, LOG);
+            if (!Utils.isClean(id)) {
+                stringBuilder.append("id ").append(id).append(" was not clean");
             }
+            return ErrorHandler.newHttpError(
+                    stringBuilder.toString(),
+                    BAD_REQUEST,
+                    LOG);
+        }
+
+        ResponseEntity<JsonNode> versionsRE = getVersions(id, includeFuture, includeDrafts);
+        if (versionsRE.getStatusCode().equals(NOT_FOUND))
+            return versionsRE;
+        else if (!versionsRE.getStatusCode().equals(OK))
+            return resolveNonOKLDSResponse("GET versions of subset with id " + id + " ", versionsRE);
+        JsonNode versionsResponseBodyJSON = versionsRE.getBody();
+        if (versionsResponseBodyJSON == null)
             return ErrorHandler.newHttpError("versions response body was null", INTERNAL_SERVER_ERROR, LOG);
+        if (!versionsResponseBodyJSON.isArray())
+            return ErrorHandler.newHttpError("versions response body was not array", INTERNAL_SERVER_ERROR, LOG);
+
+        ArrayNode versionsArrayNode = (ArrayNode) versionsResponseBodyJSON;
+        for (JsonNode versionJsonNode : versionsArrayNode) {
+            String entryValidFrom = versionJsonNode.get(Field.VALID_FROM).textValue();
+            String entryValidUntil = versionJsonNode.has(Field.VALID_UNTIL) ? versionJsonNode.get(Field.VALID_UNTIL).textValue() : null;
+            if (entryValidFrom.compareTo(date) <= 0 && (entryValidUntil == null || entryValidUntil.compareTo(date) >= 0)) {
+                JsonNode codes = versionJsonNode.get(Field.CODES);
+                return new ResponseEntity<>(codes, OK);
+            }
         }
-        StringBuilder stringBuilder = new StringBuilder();
-        if (date == null){
-            stringBuilder.append("date == null. ");
-        } else if (!Utils.isYearMonthDay(date)){
-            stringBuilder.append("date ").append(date).append(" was wrong format");
-        }
-        if (!Utils.isClean(id)){
-            stringBuilder.append("id ").append(id).append(" was not clean");
-        }
-        return ErrorHandler.newHttpError(
-                stringBuilder.toString(),
-                BAD_REQUEST,
-                LOG);
+        return new ResponseEntity<>(new ObjectMapper().createArrayNode(), OK);
     }
 
     @GetMapping("/v2/subsets/schema")

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -333,11 +333,13 @@ public class SubsetsControllerV2 {
                 return ErrorHandler.newHttpError("Published subset version must have a non-empty code list", BAD_REQUEST, LOG);
 
         if (versionsSize == 0) {
-            LOG.debug("Since there are no versions from before, we post new version to LDS without checking validity overlap");
+            LOG.debug("Since there are no versions from before, we post the new version to LDS without checking validity overlap");
+            LOG.debug("Attempting to POST version nr "+versionNr+" of subset series "+seriesId+" to LDS");
             ResponseEntity<JsonNode> ldsPostRE = new LDSFacade().postVersionInSeries(seriesId, versionNr, editableVersion);
             if (!ldsPostRE.getStatusCode().is2xxSuccessful())
                 return ldsPostRE;
-            return ldsPostRE;
+            LOG.debug("Successfully POSTed version nr "+versionNr+" of subset series "+seriesId+" to LDS");
+            return new ResponseEntity<>(editableVersion, CREATED);
         }
 
         ResponseEntity<JsonNode> isOverlappingValidityRE = isOverlappingValidity(editableVersion);

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -137,8 +137,10 @@ public class SubsetsControllerV2 {
         if (status.equals(OK)) {
             JsonNode series = addLinksToSeries(subsetSeriesByIDRE.getBody());
             return new ResponseEntity<>(series, OK);
-        } else
-            return resolveNonOKLDSResponse("GET subsetSeries w id '"+id+"'", subsetSeriesByIDRE);
+        } else if (status.equals(NOT_FOUND)){
+            return ErrorHandler.newHttpError("Subset series with id "+id+" was not found", NOT_FOUND, LOG);
+        }
+        return resolveNonOKLDSResponse("GET subsetSeries w id '"+id+"'", subsetSeriesByIDRE);
     }
 
     /**

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -248,23 +248,29 @@ public class Utils {
         Iterator<String> submittedFieldNamesIterator = instance.fieldNames();
         while (submittedFieldNamesIterator.hasNext()){
             String field = submittedFieldNamesIterator.next();
+            LOG.debug("Checking the field '"+field+"' from the instance against the definition . . .");
             if (!properties.has(field)){
+                LOG.error("the definition had no such property as '"+field+"'");
                 return ErrorHandler.newHttpError(
                         "Submitted field "+field+" is not legal in ClassificationSubsetVersion",
                         BAD_REQUEST,
                         LOG);
             }
         }
-
+        LOG.debug("All the fields in the instance were present in the definition");
         ArrayNode required = (ArrayNode) definition.get("required");
+        LOG.debug("There are "+required.size()+" required fields in the definition. Checking that they are all present");
         for (JsonNode jsonNode : required) {
             String requiredField = jsonNode.asText();
+            LOG.debug("Checking that the required field "+requiredField+" is present in the instance");
             if (!instance.has(requiredField)){
+                LOG.error("The instance did not have the required field '"+requiredField+"'");
                 return ErrorHandler.newHttpError("Submitted version did not contain required field "+requiredField,
                         BAD_REQUEST,
                         LOG);
             }
         }
+        LOG.debug("The instance had all required fields, and all the present fields were defined in the schema.");
         return new ResponseEntity<>(OK);
     }
 


### PR DESCRIPTION
- Enable DELETE requests for **[EDIT:  individual versions,]** individual subset series and all their versions, and a nuclear option for deleting all subset series and all their versions. Mainly useful for debugging and admin stuff in the development stage. The nuke option should probably be removed before going prod, and DELETE requests for individual subsets should probably be limited to users with special access.
- Fixed a bug that happens when PUTing (editing) subset series.
- Improved upon responses, logging, error handling, and naming of methods and variables.
- **EDIT: Optional request parameter `includeFullVersions` can be used to include the full versions in a series that is requested by ID, in stead of the array of links to versions that is usually present**