### PR TITLE
Auto add statistical units

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/Field.java
+++ b/src/main/java/no/ssb/subsetsservice/Field.java
@@ -33,4 +33,5 @@ public class Field {
     public static final String SERIES_ID = "seriesId";
     public static final String VALID_FROM_IN_REQUESTED_RANGE = "validFromInRequestedRange";
     public static final String VALID_UNTIL_IN_REQUESTED_RANGE = "validUntilInRequestedRange";
+    public static final String STATISTICAL_UNITS = "statisticalUnits";
 }

--- a/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
@@ -87,14 +87,16 @@ public class LDSConsumer {
         // Because Spring RestTemplate fails when the response is too long, I use Apache Commons Http Client instead,
         // and pack the response into a ResponseEntity, so it feels like Spring to the user.
         // I could not get Spring WebClient to work, which would have been my first choice.
+        String urlString = LDS_URL + additional;
+        LOG.debug("GET from "+urlString);
         CloseableHttpClient httpclient = HttpClients.createDefault();
-        HttpGet httpGet = new HttpGet(LDS_URL + additional);
+        HttpGet httpGet = new HttpGet(urlString);
         CloseableHttpResponse response1 = null;
         try {
             try {
                 response1 = httpclient.execute(httpGet);
             } catch (ConnectException e){
-                return ErrorHandler.newHttpError("Could not retrieve "+LDS_URL+additional+" because of a ConnectException: "+e.toString(), HttpStatus.FAILED_DEPENDENCY, LOG);
+                return ErrorHandler.newHttpError("Could not retrieve "+urlString+" because of a ConnectException: "+e.toString(), HttpStatus.FAILED_DEPENDENCY, LOG);
             }
             System.out.println(response1.getStatusLine());
             System.out.println(response1.toString());
@@ -107,7 +109,7 @@ public class LDSConsumer {
             return responseEntity;
         } catch (Exception e) {
             e.printStackTrace();
-            return ErrorHandler.newHttpError("Could not retrieve "+LDS_URL+additional+" because of an exception: "+e.toString(), HttpStatus.INTERNAL_SERVER_ERROR, LOG);
+            return ErrorHandler.newHttpError("Could not retrieve "+urlString+" because of an exception: "+e.toString(), HttpStatus.INTERNAL_SERVER_ERROR, LOG);
         } finally {
             try {
                 if (response1 != null)
@@ -120,12 +122,11 @@ public class LDSConsumer {
 
     ResponseEntity<JsonNode> postTo(String additional, JsonNode json){
         String fullURLString = LDS_URL+additional;
-        LOG.debug("Building request for POSTing to "+fullURLString);
+        LOG.debug("POST to "+fullURLString);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
         org.springframework.http.HttpEntity<JsonNode> request = new org.springframework.http.HttpEntity<>(json, headers);
-        LOG.debug("POSTing to "+fullURLString);
         ResponseEntity<JsonNode> response = null;
         try {
             response = new RestTemplate().postForEntity(fullURLString, request, JsonNode.class);
@@ -146,8 +147,10 @@ public class LDSConsumer {
      * @return
      */
     ResponseEntity<JsonNode> putTo(String additional, JsonNode json){
+        String urlString = LDS_URL+additional;
+        LOG.debug("PUT to "+urlString);
         CloseableHttpClient httpclient = HttpClients.createDefault();
-        HttpPut httpPut = new HttpPut(LDS_URL+additional);
+        HttpPut httpPut = new HttpPut(urlString);
         httpPut.setHeader("Accept", "application/json");
         httpPut.setHeader("Content-type", "application/json");
         StringEntity stringEntity = null;
@@ -166,7 +169,7 @@ public class LDSConsumer {
             HttpEntity entity = response.getEntity();
             int status = response.getStatusLine().getStatusCode();
             HttpStatus httpStatus = HttpStatus.resolve(status);
-            LOG.debug("PUT to "+LDS_URL+additional+" - Status: "+httpStatus.toString());
+            LOG.debug("PUT to "+urlString+" - Status: "+httpStatus.toString());
             if (!httpStatus.equals(HttpStatus.CREATED) && !httpStatus.equals(HttpStatus.OK)){
                 String responseBodyString = EntityUtils.toString(entity);
                 return ErrorHandler.newHttpError(

--- a/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSConsumer.java
@@ -94,7 +94,7 @@ public class LDSConsumer {
             try {
                 response1 = httpclient.execute(httpGet);
             } catch (ConnectException e){
-                return ErrorHandler.newHttpError("Could not retrieve "+LDS_URL+additional+" because of an exception: "+e.toString(), HttpStatus.INTERNAL_SERVER_ERROR, LOG);
+                return ErrorHandler.newHttpError("Could not retrieve "+LDS_URL+additional+" because of a ConnectException: "+e.toString(), HttpStatus.FAILED_DEPENDENCY, LOG);
             }
             System.out.println(response1.getStatusLine());
             System.out.println(response1.toString());

--- a/src/main/java/no/ssb/subsetsservice/LDSFacade.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSFacade.java
@@ -12,6 +12,8 @@ import org.springframework.web.client.HttpClientErrorException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.springframework.http.HttpStatus.OK;
+
 public class LDSFacade implements LDSInterface {
 
     String API_LDS = "";
@@ -29,7 +31,7 @@ public class LDSFacade implements LDSInterface {
 
         ResponseEntity<JsonNode> allSubsetsRE = getLastUpdatedVersionOfAllSubsets();
 
-        if (allSubsetsRE.getStatusCode().equals(HttpStatus.OK)) {
+        if (allSubsetsRE.getStatusCode().equals(OK)) {
             JsonNode ldsREBody = allSubsetsRE.getBody();
             if (ldsREBody != null) {
                 if (ldsREBody.isArray()) {
@@ -56,7 +58,7 @@ public class LDSFacade implements LDSInterface {
             String versionID = version.get("_links").get("self").get("href").asText();
         }
         */
-        return new ResponseEntity<>(versionArrayNode, HttpStatus.OK);
+        return new ResponseEntity<>(versionArrayNode, OK);
     }
 
     /**
@@ -85,11 +87,11 @@ public class LDSFacade implements LDSInterface {
     }
 
     public boolean existsSubsetWithID(String id){
-        return new LDSConsumer(API_LDS).getFrom(SUBSETS_API+"/"+id).getStatusCode().equals(HttpStatus.OK);
+        return new LDSConsumer(API_LDS).getFrom(SUBSETS_API+"/"+id).getStatusCode().equals(OK);
     }
 
     public boolean existsSubsetSeriesWithID(String id){
-        return new LDSConsumer(API_LDS).getFrom(SERIES_API+"/"+id).getStatusCode().equals(HttpStatus.OK);
+        return new LDSConsumer(API_LDS).getFrom(SERIES_API+"/"+id).getStatusCode().equals(OK);
     }
 
     public ResponseEntity<JsonNode> getClassificationSubsetSchema(){
@@ -100,7 +102,7 @@ public class LDSFacade implements LDSInterface {
         ResponseEntity<JsonNode> postRE = new LDSConsumer(API_LDS).postTo(SUBSETS_API+"/" + id, subset);
         HttpStatus status = postRE.getStatusCode();
         if (status.is2xxSuccessful())
-            status = HttpStatus.OK;
+            status = OK;
         if (postRE.hasBody())
             return new ResponseEntity<>(postRE.getBody(), postRE.getHeaders(), status);
         return new ResponseEntity<>(postRE.getHeaders(), status);
@@ -115,12 +117,12 @@ public class LDSFacade implements LDSInterface {
     }
 
     public boolean healthReady() {
-        return new LDSConsumer(API_LDS).getFrom("/health/ready").getStatusCode().equals(HttpStatus.OK);
+        return new LDSConsumer(API_LDS).getFrom("/health/ready").getStatusCode().equals(OK);
     }
 
     public void deleteSubset(String id) {
         String url = SUBSETS_API+"/"+id;
-       new LDSConsumer(API_LDS).delete(url);
+        new LDSConsumer(API_LDS).delete(url);
     }
 
     public ResponseEntity<JsonNode> editSeries(JsonNode series, String id) {
@@ -143,7 +145,7 @@ public class LDSFacade implements LDSInterface {
         }
         logger.debug("Attempting to PUT link from series with seriesID "+seriesID+" to version with UID "+versionUID+" to LDS");
         ResponseEntity<JsonNode> putLinkRE = new LDSConsumer(API_LDS).putTo(SERIES_API+"/"+seriesID+"/versions/ClassificationSubsetVersion/"+versionUID, new ObjectMapper().createObjectNode());
-        if (!putLinkRE.getStatusCode().equals(HttpStatus.OK)) {
+        if (!putLinkRE.getStatusCode().equals(OK)) {
             return ErrorHandler.newHttpError("Trying to PUT a link between the subset Series "+seriesID+" and subset Version "+versionUID+" in LDS failed, with status code "+putLinkRE.getStatusCode(), putLinkRE.getStatusCode(), logger);
         }
         logger.debug("Successfully posted and linked version with UID "+versionUID+" to subset series with id "+seriesID);
@@ -173,7 +175,7 @@ public class LDSFacade implements LDSInterface {
             return versionSchemaRE;
         }
         JsonNode definition = versionSchemaRE.getBody().get("definitions").get("ClassificationSubsetSeries");
-        return new ResponseEntity<>(definition, HttpStatus.OK);
+        return new ResponseEntity<>(definition, OK);
     }
 
     @Override
@@ -188,16 +190,31 @@ public class LDSFacade implements LDSInterface {
             return versionSchemaRE;
         }
         JsonNode definition = versionSchemaRE.getBody().get("definitions").get("ClassificationSubsetVersion");
-        return new ResponseEntity<>(definition, HttpStatus.OK);
+        return new ResponseEntity<>(definition, OK);
     }
 
     @Override
-    public void deleteAllSubsetSeries() {
-        //TODO: implement
+    public ResponseEntity<JsonNode> deleteAllSubsetSeries() {
+        ResponseEntity<JsonNode> getAllRE = getAllSubsetSeries();
+        ArrayNode allSeriesArrayNode = (ArrayNode) getAllRE.getBody();
+        for (JsonNode series : allSeriesArrayNode){
+            String id = series.get(Field.ID).asText();
+            deleteSubsetSeries(id);
+        }
+        return new ResponseEntity<>(OK);
     }
 
     @Override
-    public void deleteSubsetSeries(String id) {
-        //TODO: implement
+    public ResponseEntity<JsonNode> deleteSubsetSeries(String id) {
+        ResponseEntity<JsonNode> getSeriesRE = getSubsetSeries(id);
+        ArrayNode versionsArrayNode = (ArrayNode)getSeriesRE.getBody().get(Field.VERSIONS);
+        for(JsonNode versionLink : versionsArrayNode){
+            String[] splitSlash = versionLink.asText().split("/");
+            String versionUID = splitSlash[splitSlash.length-1];
+            new LDSConsumer(API_LDS).delete(VERSIONS_API+"/"+versionUID);
+        }
+        String url = SERIES_API+"/"+id;
+        new LDSConsumer(API_LDS).delete(url);
+        return new ResponseEntity<>(OK);
     }
 }

--- a/src/main/java/no/ssb/subsetsservice/LDSInterface.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSInterface.java
@@ -1,7 +1,6 @@
 package no.ssb.subsetsservice;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 
@@ -89,7 +88,7 @@ public interface LDSInterface {
 
     ResponseEntity<JsonNode> getSubsetVersionsDefinition();
 
-    void deleteAllSubsetSeries();
+    ResponseEntity<JsonNode> deleteAllSubsetSeries();
 
-    void deleteSubsetSeries(String id);
+    ResponseEntity<JsonNode> deleteSubsetSeries(String id);
 }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -154,7 +154,7 @@ public class SubsetsControllerV2 {
      * @return
      */
     @PutMapping(value = "/v2/subsets/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<JsonNode> putSubset(@PathVariable("id") String seriesId, @RequestBody JsonNode newVersionOfSeries) {
+    public ResponseEntity<JsonNode> putSubsetSeries(@PathVariable("id") String seriesId, @RequestBody JsonNode newVersionOfSeries) {
         metricsService.incrementPUTCounter();
         LOG.info("PUT subset series with id "+seriesId);
 
@@ -368,7 +368,7 @@ public class SubsetsControllerV2 {
     }
 
     @PostMapping(value = "/v2/subsets/{seriesId}/versions", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<JsonNode> putSubsetVersion(@PathVariable("seriesId") String seriesId, @RequestBody JsonNode version) {
+    public ResponseEntity<JsonNode> postSubsetVersion(@PathVariable("seriesId") String seriesId, @RequestBody JsonNode version) {
         if (!Utils.isClean(seriesId))
             return ErrorHandler.illegalID(LOG);
 

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -134,13 +134,12 @@ public class SubsetsControllerV2 {
 
         ResponseEntity<JsonNode> subsetSeriesByIDRE = new LDSFacade().getSubsetSeries(id);
         HttpStatus status = subsetSeriesByIDRE.getStatusCode();
+        LOG.debug("Call to LDSFacade to get a subset series with id "+id+" returned "+status.toString());
         if (status.equals(OK)) {
             JsonNode series = addLinksToSeries(subsetSeriesByIDRE.getBody());
             return new ResponseEntity<>(series, OK);
-        } else if (status.equals(NOT_FOUND)){
-            return ErrorHandler.newHttpError("Subset series with id "+id+" was not found", NOT_FOUND, LOG);
-        }
-        return resolveNonOKLDSResponse("GET subsetSeries w id '"+id+"'", subsetSeriesByIDRE);
+        } else
+            return subsetSeriesByIDRE;
     }
 
     /**

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -173,9 +173,11 @@ public class SubsetsControllerV2 {
             return resolveNonOKLDSResponse("GET subsetSeries w id '"+seriesId+"'", getSeriesRE);
         }
 
-        JsonNode currentLatestEditionOfSeries = getSeriesRE.getBody();
+        ObjectNode currentLatestEditionOfSeries = getSeriesRE.getBody().deepCopy();
+        currentLatestEditionOfSeries.remove(Field._LINKS);
         ObjectNode editableNewVersionOfSeries = newVersionOfSeries.deepCopy();
         newVersionOfSeries = null;
+        editableNewVersionOfSeries.remove(Field._LINKS);
 
         ArrayNode oldVersionsArray = currentLatestEditionOfSeries.has(Field.VERSIONS) ? currentLatestEditionOfSeries.get(Field.VERSIONS).deepCopy() : new ObjectMapper().createArrayNode();
         editableNewVersionOfSeries.set(Field.VERSIONS, oldVersionsArray);

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -695,11 +695,12 @@ public class SubsetsControllerV2 {
         return new LDSFacade().getSubsetSeriesSchema();
     }
 
+    @DeleteMapping("/v2/subsets")
     void deleteAllSeries(){
         new LDSFacade().deleteAllSubsetSeries();
     }
-
-    void deleteSeriesById(String id){
+    @DeleteMapping("/v2/subsets/{id}")
+    void deleteSeriesById(@PathVariable("id") String id){
         new LDSFacade().deleteSubsetSeries(id);
     }
 

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -137,8 +137,10 @@ public class SubsetsControllerV2 {
         if (status.equals(OK)) {
             JsonNode series = addLinksToSeries(subsetSeriesByIDRE.getBody());
             return new ResponseEntity<>(series, OK);
-        } else
-            return resolveNonOKLDSResponse("GET subsetSeries w id '"+id+"'", subsetSeriesByIDRE);
+        } else if (status.equals(NOT_FOUND)){
+            return ErrorHandler.newHttpError("Subset series with id "+id+" was not found", NOT_FOUND, LOG);
+        }
+        return resolveNonOKLDSResponse("GET subsetSeries w id '"+id+"'", subsetSeriesByIDRE);
     }
 
     /**

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -248,23 +248,29 @@ public class Utils {
         Iterator<String> submittedFieldNamesIterator = instance.fieldNames();
         while (submittedFieldNamesIterator.hasNext()){
             String field = submittedFieldNamesIterator.next();
+            LOG.debug("Checking the field '"+field+"' from the instance against the definition . . .");
             if (!properties.has(field)){
+                LOG.error("the definition had no such property as '"+field+"'");
                 return ErrorHandler.newHttpError(
                         "Submitted field "+field+" is not legal in ClassificationSubsetVersion",
                         BAD_REQUEST,
                         LOG);
             }
         }
-
+        LOG.debug("All the fields in the instance were present in the definition");
         ArrayNode required = (ArrayNode) definition.get("required");
+        LOG.debug("There are "+required.size()+" required fields in the definition. Checking that they are all present");
         for (JsonNode jsonNode : required) {
             String requiredField = jsonNode.asText();
+            LOG.debug("Checking that the required field "+requiredField+" is present in the instance");
             if (!instance.has(requiredField)){
+                LOG.error("The instance did not have the required field '"+requiredField+"'");
                 return ErrorHandler.newHttpError("Submitted version did not contain required field "+requiredField,
                         BAD_REQUEST,
                         LOG);
             }
         }
+        LOG.debug("The instance had all required fields, and all the present fields were defined in the schema.");
         return new ResponseEntity<>(OK);
     }
 


### PR DESCRIPTION
When we discussed "statistical units" and that they were not really always "statistical units", and whether to include them, I got the feeling that we should just forget about it for now. However, at that point I had already written this code for automatic resolution of statistical units. 

The way it works is that it compiles a set of all classifications used in the subset, and then it compiles the union of statistical units used in all those classifications.

Since the work is already done and it works, I decided to commit and push it. It doesn't hurt to have, I guess? If we accept it and it gets in the way later we can just remove it again.

I wrote this while writing #114, and this is a branch from that branch, so we should merge #114 first either way.