### PR TITLE
Auto-update validUntil of previous last version to be day before validFrom of new last version

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -459,12 +459,10 @@ public class SubsetsControllerV2 {
             if (latestPublishedVersion == null)
                 return ErrorHandler.newHttpError("There is supposedly other published versions, and the posted version is the new latest version, but the old latest version returned from the overlap check was null", INTERNAL_SERVER_ERROR, LOG);
             if ((!latestPublishedVersion.has(Field.VALID_UNTIL) || latestPublishedVersion.get(Field.VALID_UNTIL).isNull())) {
-                LOG.debug("The latestPublishedVersion did not have a validUntil date. Attempting to set it to one day before the validFrom of the new latest version");
-                LocalDate validFromLocalDate = LocalDate.parse(newVersion.get(Field.VALID_FROM).asText());
-                LocalDate newValidUntilOfLastVersion = validFromLocalDate.minusDays(1);
-                latestPublishedVersion.put(Field.VALID_UNTIL, newValidUntilOfLastVersion.toString());
+                LOG.debug("The latestPublishedVersion did not have a validUntil date. Attempting to set it to the validFrom of the new version");
+                latestPublishedVersion.put(Field.VALID_UNTIL, newVersion.get(Field.VALID_FROM).asText());
                 latestPublishedVersion.remove(Field._LINKS);
-                LOG.debug("Attempting to PUT the previous latest version with a new validUntil that is one day before the validFrom of the new latest version");
+                LOG.debug("Attempting to PUT the previous latest version with a new validUntil that is the same as the validFrom of the new version");
                 ResponseEntity<JsonNode> putVersionRE = putSubsetVersion(seriesId, latestPublishedVersion.get(Field.VERSION).asText(), latestPublishedVersion);
                 if (!putVersionRE.getStatusCode().is2xxSuccessful()){
                     return ErrorHandler.newHttpError("Failed to update the validUntil of the previous last published version. PUT caused error code "+putVersionRE.getStatusCode()+" and had body "+(putVersionRE.hasBody() && putVersionRE.getBody() != null ? putVersionRE.getBody().toPrettyString().replaceAll("\n", "").replaceAll("\r", "").replaceAll("\t", "") : ""), INTERNAL_SERVER_ERROR, LOG);

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -12,6 +12,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDate;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -288,10 +289,12 @@ public class SubsetsControllerV2 {
                     (previousEditionOfVersion.has(Field.VALID_UNTIL) && (!editablePutVersion.has(Field.VALID_UNTIL)) || !editablePutVersion.get(Field.VALID_UNTIL).equals(previousEditionOfVersion.get(Field.VALID_UNTIL))) ||
                     (editablePutVersion.has(Field.VALID_UNTIL) && !previousEditionOfVersion.has(Field.VALID_UNTIL)) ){
                 // check validity period overlap with other OPEN versions
-                ResponseEntity<JsonNode> checkOverlapRE = isOverlappingValidity(editablePutVersion);
-                if (!checkOverlapRE.getStatusCode().is2xxSuccessful()){
-                    return checkOverlapRE;
+                ResponseEntity<JsonNode> isOverlappingValidityRE = isOverlappingValidity(editablePutVersion);
+                if (!isOverlappingValidityRE.getStatusCode().is2xxSuccessful()){
+                    return isOverlappingValidityRE;
                 }
+                // TODO: If checkOverlapRE shows that the new published version is now the last version, edit previous last version to end when this one starts
+
             }
         } else { // Another stricter set of rules for if the old version is OPEN
             String oldCodeList = previousEditionOfVersion.get(Field.CODES).asText();
@@ -431,11 +434,8 @@ public class SubsetsControllerV2 {
         ResponseEntity<JsonNode> isOverlappingValidityRE = isOverlappingValidity(editableVersion);
         if (!isOverlappingValidityRE.getStatusCode().is2xxSuccessful())
             return isOverlappingValidityRE;
-        JsonNode isOverlapREBody = isOverlappingValidityRE.getBody();
 
-        if (isOverlapREBody.get("existOtherPublishedVersions").asBoolean() && isOverlapREBody.get("isNewLatestVersion").asBoolean()) {
-            //TODO: IF the new version is the new latest version, set the validUntil of the prev version to be the validFrom of this version
-        }
+        ResponseEntity<JsonNode> updateLatestPublishedValidUntilRE = updateLatestPublishedValidUntil(isOverlappingValidityRE, editableVersion, seriesId);
 
         LOG.debug("Attempting to POST version nr "+versionNr+" of subset series "+seriesId+" to LDS");
         ResponseEntity<JsonNode> ldsPostRE = new LDSFacade().postVersionInSeries(seriesId, versionNr, editableVersion);
@@ -445,6 +445,32 @@ public class SubsetsControllerV2 {
             return new ResponseEntity<>(editableVersion, CREATED);
         } else
             return ldsPostRE;
+    }
+
+    private ResponseEntity<JsonNode> updateLatestPublishedValidUntil(ResponseEntity<JsonNode> isOverlappingValidityRE, JsonNode newVersion, String seriesId){
+        JsonNode isOverlapREBody = isOverlappingValidityRE.getBody();
+        if (isOverlapREBody.get("existOtherPublishedVersions").asBoolean() && isOverlapREBody.get("isNewLatestVersion").asBoolean()) {
+            LOG.debug("according to the overlap check there is a previously published version, and the new version is the new latest version");
+            ObjectNode latestPublishedVersion = isOverlapREBody.get("latestPublishedVersion").deepCopy();
+            if (latestPublishedVersion == null)
+                return ErrorHandler.newHttpError("There is supposedly other published versions, and the posted version is the new latest version, but the old latest version returned from the overlap check was null", INTERNAL_SERVER_ERROR, LOG);
+            if ((!latestPublishedVersion.has(Field.VALID_UNTIL) || latestPublishedVersion.get(Field.VALID_UNTIL).isNull())) {
+                LOG.debug("The latestPublishedVersion did not have a validUntil date. Attempting to set it to one day before the validFrom of the new latest version");
+                LocalDate validFromLocalDate = LocalDate.parse(newVersion.get(Field.VALID_FROM).asText());
+                LocalDate newValidUntilOfLastVersion = validFromLocalDate.minusDays(1);
+                latestPublishedVersion.put(Field.VALID_UNTIL, newValidUntilOfLastVersion.toString());
+                LOG.debug("Attempting to PUT the previous latest version with a new validUntil that is one day before the validFrom of the new latest version");
+                ResponseEntity<JsonNode> putVersionRE = putSubsetVersion(seriesId, latestPublishedVersion.get(Field.VERSION).asText(), latestPublishedVersion);
+                if (!putVersionRE.getStatusCode().is2xxSuccessful()){
+                    return ErrorHandler.newHttpError("Failed to update the validUntil of the previous last published version. PUT caused error code "+putVersionRE.getStatusCode()+" and had body "+(putVersionRE.hasBody() && putVersionRE.getBody() != null ? putVersionRE.getBody().toPrettyString().replaceAll("\n", "").replaceAll("\r", "").replaceAll("\t", "") : ""), INTERNAL_SERVER_ERROR, LOG);
+                }
+            } else {
+                LOG.debug("The latestPublishedVersion already had a validUntil date");
+            }
+        } else {
+            LOG.debug("Either there are no other published versions, or the published version is not the new latest version");
+        }
+        return new ResponseEntity<>(OK);
     }
 
     @GetMapping("/v2/subsets/{id}/versions")
@@ -844,8 +870,8 @@ public class SubsetsControllerV2 {
         String validFrom = editableVersion.get(Field.VALID_FROM).asText();
         String validUntil = editableVersion.has(Field.VALID_UNTIL) ? editableVersion.get(Field.VALID_UNTIL).asText() : null;
         String seriesID = editableVersion.get(Field.SERIES_ID).asText();
-        ResponseEntity<JsonNode> getVersionsRE = getVersions(seriesID, true, false);
-        if (getVersionsRE.getStatusCode().equals(NOT_FOUND)) {
+        ResponseEntity<JsonNode> getPublishedVersionsRE = getVersions(seriesID, true, false);
+        if (getPublishedVersionsRE.getStatusCode().equals(NOT_FOUND)) {
             ObjectNode body = new ObjectMapper().createObjectNode();
             body.put("message", "Subset getVersions returned 404 NOT FOUND, which means there is no overlap");
             body.put("status", OK.value());
@@ -854,26 +880,29 @@ public class SubsetsControllerV2 {
             body.put("isNewFirstVersion", true);
             return new ResponseEntity<>(body, OK); // No overlap if no versions found
         }
-        if (!getVersionsRE.getStatusCode().is2xxSuccessful())
-            return getVersionsRE; // FIXME
+        if (!getPublishedVersionsRE.getStatusCode().is2xxSuccessful())
+            return getPublishedVersionsRE; // FIXME
 
         boolean isNewLatestVersion = true;
         boolean isNewFirstVersion = true;
-        ArrayNode subsetVersionsArray = getVersionsRE.getBody().deepCopy();
+        ArrayNode publishedSubsetVersionsArrayNode = getPublishedVersionsRE.getBody().deepCopy();
 
         boolean existOtherPublishedVersions = false;
-        if (!subsetVersionsArray.isEmpty()){
+        JsonNode latestPublishedVersion = null;
+        if (!publishedSubsetVersionsArrayNode.isEmpty()){
             existOtherPublishedVersions = true;
             String firstValidFrom = null;
             String lastValidFrom = null;
-            for (JsonNode versionJsonNode : subsetVersionsArray) {
+            for (JsonNode versionJsonNode : publishedSubsetVersionsArrayNode) {
                 if (versionJsonNode.get(Field.ADMINISTRATIVE_STATUS).asText().equals(Field.OPEN)) { // We only care about checking against published subset versions
                     LOG.debug("Checking version "+versionJsonNode.get(Field.SERIES_ID).asText()+"_"+versionJsonNode.get(Field.VERSION).asText()+" for overlap with the new version, since it is published.");
                     String versionValidFrom = versionJsonNode.get(Field.VALID_FROM).asText();
                     if (firstValidFrom == null || versionValidFrom.compareTo(firstValidFrom) < 0)
                         firstValidFrom = versionValidFrom;
-                    if (lastValidFrom == null || versionValidFrom.compareTo(lastValidFrom) > 0)
+                    if (lastValidFrom == null || versionValidFrom.compareTo(lastValidFrom) > 0) {
                         lastValidFrom = versionValidFrom;
+                        latestPublishedVersion = versionJsonNode;
+                    }
 
                     if (validFrom.compareTo(versionValidFrom) == 0)
                         return ErrorHandler.newHttpError(
@@ -892,7 +921,7 @@ public class SubsetsControllerV2 {
                                     BAD_REQUEST,
                                     LOG);
                         }
-                    } else { // ValidUntil is null, which is only the case if the new version is supposed to be the new latest version
+                    } else { // ValidUntil is null, which is ONLY allowed to be the case if the new version is supposed to be the new latest version
                         if (versionValidFrom.compareTo(validFrom) >= 0)
                             return ErrorHandler.newHttpError(
                                     "If a validUntil is not set for a posted version, it must be the new latest subset series version ",
@@ -942,6 +971,7 @@ public class SubsetsControllerV2 {
         body.put("existOtherPublishedVersions", existOtherPublishedVersions);
         body.put("isNewLatestVersion", isNewLatestVersion);
         body.put("isNewFirstVersion", isNewFirstVersion);
+        body.set("latestPublishedVersion", latestPublishedVersion);
         return new ResponseEntity<>(body, OK);
     }
 

--- a/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
@@ -1001,6 +1001,34 @@ class SubsetsControllerV2Test {
     }
 
     @Test
+    void getSubsetCodesToday() {
+        SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
+
+        JsonNode series = readJsonFile(series_2_0);
+        String seriesId = series.get(Field.ID).asText();
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
+
+        JsonNode version201validUntil = readJsonFile(version_2_0_1);
+        ResponseEntity<JsonNode> postVersion1validUntilRE = instance.postSubsetVersion(seriesId, version201validUntil);
+        assertEquals(HttpStatus.CREATED, postVersion1validUntilRE.getStatusCode());
+
+        JsonNode version202validUntil = readJsonFile(version_2_0_2);
+        ResponseEntity<JsonNode> postVersion2validUntilRE = instance.postSubsetVersion(seriesId, version202validUntil);
+        assertEquals(HttpStatus.CREATED, postVersion2validUntilRE.getStatusCode());
+
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        ResponseEntity<JsonNode> getCodesTodayRE = instance.getSubsetCodes(seriesId, null, null, true, true);
+        System.out.println("GET codes from a version that is valid today (codes need not be valid today, just the version) ");
+        System.out.println(getCodesTodayRE.getBody().toPrettyString());
+    }
+
+    @Test
     void getSubsetCodesInDateRange() {
         SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
 

--- a/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 
 import java.io.File;
 import java.io.IOException;
+import java.sql.SQLOutput;
 import java.time.Clock;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -712,6 +713,57 @@ class SubsetsControllerV2Test {
         System.out.println(versionsArrayNode.toPrettyString());
         System.out.println();
         assertEquals(2, versionsArrayNode.size());
+    }
+
+    @Test
+    void postNewVersionThatSetsValidUntilOfPreviousVersionToOneDayBeforeValidFromOfNewVersion(){
+        SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
+        JsonNode series = readJsonFile(series_1_0);
+        String seriesId = series.get(Field.ID).asText();
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
+
+        JsonNode version_2_0_2 = readJsonFile(this.version_2_0_2);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, version_2_0_2);
+        String version202_uid = postVersionRE.getBody().get(Field.VERSION).asText();
+        assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
+        assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
+
+        // DANGER: POSTing two versions right after each other often leads to overwriting the first version.
+        // Therefore we sleep for a bit
+        try {
+            Thread.sleep(50);
+        } catch (InterruptedException e) {
+            fail("Sleep failed");
+        }
+
+        JsonNode version_2_0_3 = readJsonFile(this.version_2_0_3);
+        ResponseEntity<JsonNode> putVersionRE = instance.postSubsetVersion(seriesId, version_2_0_3);
+        assertEquals(HttpStatus.CREATED, putVersionRE.getStatusCode());
+
+        try {
+            Thread.sleep(50); //To make sure the resource is available from LDS before we GET it
+        } catch (InterruptedException e) {
+            fail("Sleep failed");
+        }
+
+        ResponseEntity<JsonNode> getVersionsRE = instance.getVersions(seriesId, true, true);
+        assertEquals(HttpStatus.OK, getVersionsRE.getStatusCode());
+        JsonNode getVersionsBody = getVersionsRE.getBody();
+        assertTrue(getVersionsBody.isArray());
+        ArrayNode versionsArrayNode = (ArrayNode)getVersionsBody;
+        System.out.println("*** VERSIONS ARRAY NODE ***");
+        System.out.println(versionsArrayNode.toPrettyString());
+        System.out.println();
+        assertEquals(2, versionsArrayNode.size());
+
+        JsonNode version202AfterUpdate = instance.getVersion(seriesId, version202_uid).getBody();
+        assertNotNull(version202AfterUpdate);
+        assertTrue(version202AfterUpdate.has(Field.VALID_UNTIL));
+        String validUntilAfterUpdate = version202AfterUpdate.get(Field.VALID_UNTIL).asText();
+        System.out.println("version 202 validUntil after update: "+validUntilAfterUpdate);
+        System.out.println("version 203 validFrom: "+version_2_0_3.get(Field.VALID_FROM).asText());
+        assertTrue(validUntilAfterUpdate.compareTo(version_2_0_3.get(Field.VALID_FROM).asText()) < 0);
     }
 
     @Test

--- a/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
@@ -763,7 +763,7 @@ class SubsetsControllerV2Test {
         String validUntilAfterUpdate = version202AfterUpdate.get(Field.VALID_UNTIL).asText();
         System.out.println("version 202 validUntil after update: "+validUntilAfterUpdate);
         System.out.println("version 203 validFrom: "+version_2_0_3.get(Field.VALID_FROM).asText());
-        assertTrue(validUntilAfterUpdate.compareTo(version_2_0_3.get(Field.VALID_FROM).asText()) < 0);
+        assertTrue(validUntilAfterUpdate.compareTo(version_2_0_3.get(Field.VALID_FROM).asText()) == 0);
     }
 
     @Test


### PR DESCRIPTION
If the currently valid version does not have an explicit validUntil value and a new version is published with a validFrom after the currently valid version's validFrom, we auto-set the validUntil of curent open version to be day before validFrom of the new last version that you publish.

I also wrote a unit test that checks if this works in the basic case.