### PR TITLE
Accept and remove extra fields from POST/PUT

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/LDSFacade.java
+++ b/src/main/java/no/ssb/subsetsservice/LDSFacade.java
@@ -28,23 +28,16 @@ public class LDSFacade implements LDSInterface {
         this.API_LDS = API_LDS;
     }
 
-    public ResponseEntity<JsonNode> getVersionsInSubsetWithID(String subsetId) {
-        ResponseEntity<JsonNode> seriesRE = new LDSConsumer(API_LDS).getFrom(SERIES_API+"/"+subsetId);
-        JsonNode subsetSeriesJsonNode = seriesRE.getBody();
-        ArrayNode versionArrayNode = subsetSeriesJsonNode.get("versions").deepCopy();
-        return new ResponseEntity<>(versionArrayNode, OK);
-    }
-
     /**
      * Get a specific subset version by its UID, without going through the subset series.
      * @param versionId is the UID for the version, unique among all versions, that is used in LDS
      * @return
      */
-    public ResponseEntity<JsonNode> getVersionByID(String versionId){
+    public ResponseEntity<JsonNode> getVersionByID(String versionId) {
         return new LDSConsumer(API_LDS).getFrom(VERSIONS_API+"/"+versionId);
     }
 
-    public ResponseEntity<JsonNode> getSubsetSeries(String id){
+    public ResponseEntity<JsonNode> getSubsetSeries(String id) {
         return new LDSConsumer(API_LDS).getFrom(SERIES_API+"/"+id);
     }
 
@@ -52,11 +45,11 @@ public class LDSFacade implements LDSInterface {
         return new LDSConsumer(API_LDS).getFrom(SERIES_API+"");
     }
 
-    public boolean existsSubsetSeriesWithID(String id){
+    public boolean existsSubsetSeriesWithID(String id) {
         return new LDSConsumer(API_LDS).getFrom(SERIES_API+"/"+id).getStatusCode().equals(OK);
     }
 
-    public ResponseEntity<JsonNode> createSubsetSeries(JsonNode subset, String id){
+    public ResponseEntity<JsonNode> createSubsetSeries(JsonNode subset, String id) {
         return new LDSConsumer(API_LDS).postTo(SERIES_API+"/" + id, subset);
     }
 
@@ -145,7 +138,7 @@ public class LDSFacade implements LDSInterface {
     public ResponseEntity<JsonNode> deleteAllSubsetSeries() {
         ResponseEntity<JsonNode> getAllRE = getAllSubsetSeries();
         ArrayNode allSeriesArrayNode = (ArrayNode) getAllRE.getBody();
-        for (JsonNode series : allSeriesArrayNode){
+        for (JsonNode series : allSeriesArrayNode) {
             String id = series.get(Field.ID).asText();
             deleteSubsetSeries(id);
         }

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -831,12 +831,16 @@ public class SubsetsControllerV2 {
         version = null;
 
         Iterator<String> submittedFieldNamesIterator = editableVersion.fieldNames();
+        List<String> fieldsToBeDeleted = new ArrayList<>();
         while (submittedFieldNamesIterator.hasNext()) {
             String field = submittedFieldNamesIterator.next();
             if (!definitionProperties.has(field)) {
                 LOG.debug("removing the field "+field+" from the item because it was not defined in the schema");
-                editableVersion.remove(field);
+                fieldsToBeDeleted.add(field);
             }
+        }
+        for (String fieldName : fieldsToBeDeleted) {
+            editableVersion.remove(fieldName);
         }
         if (definitionProperties.has(Field.CODES)) {
             JsonNode codesProperty = definitionProperties.get(Field.CODES);
@@ -855,12 +859,16 @@ public class SubsetsControllerV2 {
                             for (JsonNode code : codesArray) {
                                 ObjectNode editableCodeNode = code.deepCopy();
                                 Iterator<String> codeFieldNamesIterator = editableCodeNode.fieldNames();
+                                fieldsToBeDeleted = new ArrayList<>();
                                 while (codeFieldNamesIterator.hasNext()) {
                                     String field = codeFieldNamesIterator.next();
-                                    if (!codeDefinition.has(field)) {
-                                        LOG.debug("removing the field "+field+" from a subset version Code because it was not defined in the schema");
-                                        editableCodeNode.remove(field);
+                                    if (!codeDefinition.get("properties").has(field)) {
+                                        LOG.debug("removing the field "+field+" from a code because it was not defined in the schema");
+                                        fieldsToBeDeleted.add(field);
                                     }
+                                }
+                                for (String fieldName : fieldsToBeDeleted) {
+                                    editableCodeNode.remove(fieldName);
                                 }
                                 newCodesArray.add(editableCodeNode);
                             }

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -215,6 +215,7 @@ public class Utils {
             else if (definitionPoperties.get(field).has("type") && definitionPoperties.get(field).get("type").asText().equals("array") && !instance.get(field).isArray())
                 return ErrorHandler.newHttpError("Submitted field "+field+" has to be an array according to the definition, but was not an array", BAD_REQUEST, LOG);
         }
+
         if (definitionPoperties.has("codes")) {
             LOG.debug("'codes' field present in definition. Checking each element of instance against ClassificationSubsetCode definition");
             JsonNode codesProperty = definitionPoperties.get("codes");

--- a/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
@@ -129,7 +129,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
@@ -176,7 +176,7 @@ class SubsetsControllerV2Test {
         assertEquals(originalNbDescription, newNbDescription);
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
@@ -214,13 +214,13 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
         String versionUID = postVersionRE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode versionOpen = readJsonFile(version_1_0_1_open);
-        ResponseEntity<JsonNode> putOpenVersionRE = instance.putSubsetVersion(seriesId, versionUID, versionOpen);
+        ResponseEntity<JsonNode> putOpenVersionRE = instance.putSubsetVersion(seriesId, versionUID, false, versionOpen);
         assertTrue(putOpenVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.OK, putOpenVersionRE.getStatusCode());
     }
@@ -237,7 +237,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
         try {
             Thread.sleep(100); //To make sure the resource is available from LDS before we GET it
@@ -264,7 +264,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
         String versionUID1 = postVersionRE.getBody().get(Field.VERSION_ID).asText();
@@ -289,13 +289,13 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
         String versionUID1 = postVersionRE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode version1_0_1_1 = readJsonFile(version_1_0_1_1);
-        ResponseEntity<JsonNode> putVersionRE = instance.putSubsetVersion(seriesId, versionUID1, version1_0_1_1);
+        ResponseEntity<JsonNode> putVersionRE = instance.putSubsetVersion(seriesId, versionUID1, false, version1_0_1_1);
         assertEquals(HttpStatus.OK, putVersionRE.getStatusCode());
 
         ResponseEntity<JsonNode> getVersionRE = instance.getVersion(seriesId, versionUID1);
@@ -316,12 +316,12 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionNoCodesDraft = readJsonFile(version_1_0_1_nocodes_draft);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, versionNoCodesDraft);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionNoCodesDraft);
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
         String versionUID1 = postVersionRE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode versionNoCodesOpen = readJsonFile(version_1_0_1_nocodes_open);
-        ResponseEntity<JsonNode> putResponseEntity = instance.putSubsetVersion(seriesId, versionUID1, versionNoCodesOpen);
+        ResponseEntity<JsonNode> putResponseEntity = instance.putSubsetVersion(seriesId, versionUID1, false, versionNoCodesOpen);
         assertEquals(HttpStatus.BAD_REQUEST, putResponseEntity.getStatusCode()); // 0 codes is not allowed in published subset
     }
 
@@ -334,7 +334,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionNoCodesDraft = readJsonFile(version_1_0_1_nocodes_open);
-        ResponseEntity<JsonNode> postResponseEntity = instance.postSubsetVersion(seriesId, versionNoCodesDraft);
+        ResponseEntity<JsonNode> postResponseEntity = instance.postSubsetVersion(seriesId, false, versionNoCodesDraft);
         assertEquals(HttpStatus.BAD_REQUEST, postResponseEntity.getStatusCode());
         System.out.println(postResponseEntity.getBody().toPrettyString());
     }
@@ -349,7 +349,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
         String versionUID1 = postVersionRE.getBody().get(Field.VERSION_ID).asText();
@@ -397,7 +397,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
         String versionUID1 = postVersionRE.getBody().get(Field.VERSION_ID).asText();
@@ -445,7 +445,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
         String versionUID1 = postVersionRE.getBody().get(Field.VERSION_ID).asText();
@@ -465,7 +465,7 @@ class SubsetsControllerV2Test {
         }
 
         JsonNode version2 = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersion2RE = instance.postSubsetVersion(seriesId, version2);
+        ResponseEntity<JsonNode> postVersion2RE = instance.postSubsetVersion(seriesId, false, version2);
         assertTrue(postVersion2RE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersion2RE.getStatusCode());
         String versionUID2 = postVersion2RE.getBody().get(Field.VERSION_ID).asText();
@@ -530,7 +530,7 @@ class SubsetsControllerV2Test {
         String seriesID = seriesJsonNode.get(Field.ID).asText();
 
         JsonNode versionJsonNode = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesID, versionJsonNode);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesID, false, versionJsonNode);
         String versionUID = postVersionRE.getBody().get(Field.VERSION_ID).asText();
         JsonNode retrievedSubsetSeries = instance.getSubsetSeriesByID(seriesID, false).getBody();
         assertTrue(retrievedSubsetSeries.has(Field.LAST_MODIFIED));
@@ -552,11 +552,11 @@ class SubsetsControllerV2Test {
         instance.postSubsetSeries(seriesJsonNode);
 
         JsonNode versionOpenJsonNode = readJsonFile(version_1_0_1_open);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesID, versionOpenJsonNode);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesID, false, versionOpenJsonNode);
         String versionUID = postVersionRE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode versionDraftJsonNode = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> putDraftAfterOpenRE = instance.putSubsetVersion(seriesID, versionUID, versionDraftJsonNode);
+        ResponseEntity<JsonNode> putDraftAfterOpenRE = instance.putSubsetVersion(seriesID, versionUID, false, versionDraftJsonNode);
 
         assertEquals(HttpStatus.BAD_REQUEST, putDraftAfterOpenRE.getStatusCode());
     }
@@ -622,7 +622,7 @@ class SubsetsControllerV2Test {
         instance.postSubsetSeries(seriesJsonNode);
 
         JsonNode versionOpenJsonNode = readJsonFile(version_1_0_1_open);
-        ResponseEntity<JsonNode> putVersionRE = instance.putSubsetVersion(seriesID, "1", versionOpenJsonNode);
+        ResponseEntity<JsonNode> putVersionRE = instance.putSubsetVersion(seriesID, "1", false, versionOpenJsonNode);
         assertEquals(HttpStatus.BAD_REQUEST, putVersionRE.getStatusCode());
     }
 
@@ -635,7 +635,7 @@ class SubsetsControllerV2Test {
         instance.postSubsetSeries(seriesJsonNode);
 
         JsonNode versionDraftJsonNode = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postDraftVersionRE = instance.postSubsetVersion(seriesID, versionDraftJsonNode);
+        ResponseEntity<JsonNode> postDraftVersionRE = instance.postSubsetVersion(seriesID, false, versionDraftJsonNode);
         String lastMod1 = postDraftVersionRE.getBody().get(Field.LAST_MODIFIED).asText();
         String versionUID = postDraftVersionRE.getBody().get(Field.VERSION_ID).asText();
         try {
@@ -654,7 +654,7 @@ class SubsetsControllerV2Test {
         }
 
         JsonNode versionOpenJsonNode = readJsonFile(version_1_0_1_open);
-        ResponseEntity<JsonNode> putOpenVersionRE = instance.putSubsetVersion(seriesID, versionUID, versionOpenJsonNode);
+        ResponseEntity<JsonNode> putOpenVersionRE = instance.putSubsetVersion(seriesID, versionUID, false, versionOpenJsonNode);
         assertEquals(HttpStatus.OK, putOpenVersionRE.getStatusCode());
         String lastMod2 = putOpenVersionRE.getBody().get(Field.LAST_MODIFIED).asText();
 
@@ -682,7 +682,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
@@ -695,7 +695,7 @@ class SubsetsControllerV2Test {
         }
 
         JsonNode version1_0_1_1 = readJsonFile(version_1_0_1_1);
-        ResponseEntity<JsonNode> putVersionRE = instance.postSubsetVersion(seriesId, version1_0_1_1);
+        ResponseEntity<JsonNode> putVersionRE = instance.postSubsetVersion(seriesId, false, version1_0_1_1);
         assertEquals(HttpStatus.CREATED, putVersionRE.getStatusCode());
 
         try {
@@ -724,7 +724,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version_2_0_2 = readJsonFile(this.version_2_0_2);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, version_2_0_2);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version_2_0_2);
         String version202_uid = postVersionRE.getBody().get(Field.VERSION_ID).asText();
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
@@ -738,7 +738,7 @@ class SubsetsControllerV2Test {
         }
 
         JsonNode version_2_0_3 = readJsonFile(this.version_2_0_3);
-        ResponseEntity<JsonNode> putVersionRE = instance.postSubsetVersion(seriesId, version_2_0_3);
+        ResponseEntity<JsonNode> putVersionRE = instance.postSubsetVersion(seriesId, false, version_2_0_3);
         assertEquals(HttpStatus.CREATED, putVersionRE.getStatusCode());
 
         try {
@@ -776,7 +776,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1_open);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
@@ -786,7 +786,7 @@ class SubsetsControllerV2Test {
             e.printStackTrace();
         }
 
-        ResponseEntity<JsonNode> postVersionRE2 = instance.postSubsetVersion(seriesId, version);
+        ResponseEntity<JsonNode> postVersionRE2 = instance.postSubsetVersion(seriesId, false, version);
         assertEquals(HttpStatus.BAD_REQUEST, postVersionRE2.getStatusCode());
     }
 
@@ -838,12 +838,12 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version202 = readJsonFile(version_2_0_2);
-        ResponseEntity<JsonNode> postVersion2RE = instance.postSubsetVersion(seriesId, version202);
+        ResponseEntity<JsonNode> postVersion2RE = instance.postSubsetVersion(seriesId, false, version202);
         assertEquals(HttpStatus.CREATED, postVersion2RE.getStatusCode());
         String version2ID = postVersion2RE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode version202validUntil = readJsonFile(version_2_0_2_validUntil);
-        ResponseEntity<JsonNode> putVersion2validUntilRE = instance.putSubsetVersion(seriesId, version2ID, version202validUntil);
+        ResponseEntity<JsonNode> putVersion2validUntilRE = instance.putSubsetVersion(seriesId, version2ID, false, version202validUntil);
         assertEquals(HttpStatus.OK, putVersion2validUntilRE.getStatusCode());
     }
 
@@ -857,16 +857,16 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version201 = readJsonFile(version_2_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, version201);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version201);
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
         JsonNode version202 = readJsonFile(version_2_0_2);
-        ResponseEntity<JsonNode> postVersion2RE = instance.postSubsetVersion(seriesId, version202);
+        ResponseEntity<JsonNode> postVersion2RE = instance.postSubsetVersion(seriesId, false, version202);
         assertEquals(HttpStatus.CREATED, postVersion2RE.getStatusCode());
         String version2ID = postVersion2RE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode version202validUntil = readJsonFile(version_2_0_2_validUntil);
-        ResponseEntity<JsonNode> putVersion2validUntilRE = instance.putSubsetVersion(seriesId, version2ID, version202validUntil);
+        ResponseEntity<JsonNode> putVersion2validUntilRE = instance.putSubsetVersion(seriesId, version2ID, false, version202validUntil);
         if (!putVersion2validUntilRE.getStatusCode().is2xxSuccessful()) {
             System.out.println("*** BODY ***");
             System.out.println(putVersion2validUntilRE.getBody().toPrettyString());
@@ -874,11 +874,11 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.OK, putVersion2validUntilRE.getStatusCode());
 
         JsonNode version203_overlap = readJsonFile(version_2_0_3_overlapping_date);
-        ResponseEntity<JsonNode> postVersion3RE = instance.postSubsetVersion(seriesId, version203_overlap);
+        ResponseEntity<JsonNode> postVersion3RE = instance.postSubsetVersion(seriesId, false, version203_overlap);
         assertEquals(HttpStatus.BAD_REQUEST, postVersion3RE.getStatusCode());
 
         JsonNode version203_no_overlap = readJsonFile(version_2_0_3);
-        postVersion3RE = instance.postSubsetVersion(seriesId, version203_no_overlap);
+        postVersion3RE = instance.postSubsetVersion(seriesId, false, version203_no_overlap);
         assertEquals(HttpStatus.CREATED, postVersion3RE.getStatusCode());
     }
 
@@ -892,7 +892,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version203_overlap = readJsonFile(version_2_0_3_overlapping_date);
-        ResponseEntity<JsonNode> postVersion3RE = instance.postSubsetVersion(seriesId, version203_overlap);
+        ResponseEntity<JsonNode> postVersion3RE = instance.postSubsetVersion(seriesId, false, version203_overlap);
         assertEquals(HttpStatus.CREATED, postVersion3RE.getStatusCode());
 
         try {
@@ -902,7 +902,7 @@ class SubsetsControllerV2Test {
         }
 
         JsonNode version202validUntil = readJsonFile(version_2_0_2_validUntil);
-        ResponseEntity<JsonNode> postVersion2validUntilRE = instance.postSubsetVersion(seriesId, version202validUntil);
+        ResponseEntity<JsonNode> postVersion2validUntilRE = instance.postSubsetVersion(seriesId, false, version202validUntil);
         assertEquals(HttpStatus.BAD_REQUEST, postVersion2validUntilRE.getStatusCode());
     }
 
@@ -916,7 +916,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionDraft = readJsonFile(version_1_0_1_nocodes_draft);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, versionDraft);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionDraft);
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
         try {
@@ -926,7 +926,7 @@ class SubsetsControllerV2Test {
         }
 
         JsonNode versionOpen = readJsonFile(version_1_0_1_open);
-        ResponseEntity<JsonNode> postVersionOpenRE = instance.postSubsetVersion(seriesId, versionOpen);
+        ResponseEntity<JsonNode> postVersionOpenRE = instance.postSubsetVersion(seriesId, false, versionOpen);
         assertEquals(HttpStatus.CREATED, postVersionOpenRE.getStatusCode());
 
         try {
@@ -963,7 +963,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionDraft = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, versionDraft);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionDraft);
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
         try {
@@ -973,7 +973,7 @@ class SubsetsControllerV2Test {
         }
 
         JsonNode versionDraft2 = readJsonFile(version_1_0_1_1);
-        ResponseEntity<JsonNode> postVersionRE2 = instance.postSubsetVersion(seriesId, versionDraft2);
+        ResponseEntity<JsonNode> postVersionRE2 = instance.postSubsetVersion(seriesId, false, versionDraft2);
         assertEquals(HttpStatus.CREATED, postVersionRE2.getStatusCode());
     }
 
@@ -987,7 +987,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionDraft = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, versionDraft);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionDraft);
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
         try {
@@ -1012,7 +1012,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionDraft = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, versionDraft);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionDraft);
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
         try {
@@ -1037,7 +1037,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionDraft = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, versionDraft);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionDraft);
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
         try {
@@ -1062,11 +1062,11 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version201validUntil = readJsonFile(version_2_0_1);
-        ResponseEntity<JsonNode> postVersion1validUntilRE = instance.postSubsetVersion(seriesId, version201validUntil);
+        ResponseEntity<JsonNode> postVersion1validUntilRE = instance.postSubsetVersion(seriesId, false, version201validUntil);
         assertEquals(HttpStatus.CREATED, postVersion1validUntilRE.getStatusCode());
 
         JsonNode version202validUntil = readJsonFile(version_2_0_2);
-        ResponseEntity<JsonNode> postVersion2validUntilRE = instance.postSubsetVersion(seriesId, version202validUntil);
+        ResponseEntity<JsonNode> postVersion2validUntilRE = instance.postSubsetVersion(seriesId, false, version202validUntil);
         assertEquals(HttpStatus.CREATED, postVersion2validUntilRE.getStatusCode());
 
         try {
@@ -1090,11 +1090,11 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version201validUntil = readJsonFile(version_2_0_1);
-        ResponseEntity<JsonNode> postVersion1validUntilRE = instance.postSubsetVersion(seriesId, version201validUntil);
+        ResponseEntity<JsonNode> postVersion1validUntilRE = instance.postSubsetVersion(seriesId, false, version201validUntil);
         assertEquals(HttpStatus.CREATED, postVersion1validUntilRE.getStatusCode());
 
         JsonNode version202validUntil = readJsonFile(version_2_0_2_validUntil);
-        ResponseEntity<JsonNode> postVersion2validUntilRE = instance.postSubsetVersion(seriesId, version202validUntil);
+        ResponseEntity<JsonNode> postVersion2validUntilRE = instance.postSubsetVersion(seriesId, false, version202validUntil);
         assertEquals(HttpStatus.CREATED, postVersion2validUntilRE.getStatusCode());
 
         try {
@@ -1118,7 +1118,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version201validUntil = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersion1validUntilRE = instance.postSubsetVersion(seriesId, version201validUntil);
+        ResponseEntity<JsonNode> postVersion1validUntilRE = instance.postSubsetVersion(seriesId, false, version201validUntil);
         assertEquals(HttpStatus.CREATED, postVersion1validUntilRE.getStatusCode());
 
         try {

--- a/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
@@ -67,7 +67,7 @@ class SubsetsControllerV2Test {
     void postSubsetSeries() {
         SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
         JsonNode series = readJsonFile(series_1_0);
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
     }
 
@@ -75,7 +75,7 @@ class SubsetsControllerV2Test {
     void getAllSubsetSeries() {
         SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
         JsonNode series = readJsonFile(series_1_0);
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         ResponseEntity<JsonNode> getSeriesRE = instance.getSubsetSeries( true, true, true);
@@ -92,7 +92,7 @@ class SubsetsControllerV2Test {
         SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         ResponseEntity<JsonNode> getSeriesRE = instance.getSubsetSeriesByID(seriesId, false);
@@ -109,10 +109,10 @@ class SubsetsControllerV2Test {
         JsonNode series = readJsonFile(series_1_0);
         JsonNode series1_1 = readJsonFile(series_1_1);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
-        ResponseEntity<JsonNode> putSeriesRE = instance.putSubsetSeries(seriesId, series1_1);
+        ResponseEntity<JsonNode> putSeriesRE = instance.putSubsetSeries(seriesId, false, series1_1);
         assertEquals(HttpStatus.OK, putSeriesRE.getStatusCode());
 
         //TODO: Make sure versions list was not overwritten, and createdDate automatically carried over.
@@ -125,7 +125,7 @@ class SubsetsControllerV2Test {
         SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false,  series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
@@ -150,7 +150,7 @@ class SubsetsControllerV2Test {
         SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         try {
@@ -210,7 +210,7 @@ class SubsetsControllerV2Test {
         SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
@@ -233,7 +233,7 @@ class SubsetsControllerV2Test {
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
 
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
@@ -260,7 +260,7 @@ class SubsetsControllerV2Test {
         SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
@@ -285,7 +285,7 @@ class SubsetsControllerV2Test {
         SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
@@ -312,7 +312,7 @@ class SubsetsControllerV2Test {
         SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionNoCodesDraft = readJsonFile(version_1_0_1_nocodes_draft);
@@ -330,7 +330,7 @@ class SubsetsControllerV2Test {
         SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionNoCodesDraft = readJsonFile(version_1_0_1_nocodes_open);
@@ -345,7 +345,7 @@ class SubsetsControllerV2Test {
 
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
@@ -393,7 +393,7 @@ class SubsetsControllerV2Test {
 
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
@@ -441,7 +441,7 @@ class SubsetsControllerV2Test {
 
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
@@ -526,7 +526,7 @@ class SubsetsControllerV2Test {
         SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
 
         JsonNode seriesJsonNode = readJsonFile(series_1_0);
-        instance.postSubsetSeries(seriesJsonNode);
+        instance.postSubsetSeries(false, seriesJsonNode);
         String seriesID = seriesJsonNode.get(Field.ID).asText();
 
         JsonNode versionJsonNode = readJsonFile(version_1_0_1);
@@ -549,7 +549,7 @@ class SubsetsControllerV2Test {
 
         JsonNode seriesJsonNode = readJsonFile(series_1_0);
         String seriesID = seriesJsonNode.get(Field.ID).asText();
-        instance.postSubsetSeries(seriesJsonNode);
+        instance.postSubsetSeries(false, seriesJsonNode);
 
         JsonNode versionOpenJsonNode = readJsonFile(version_1_0_1_open);
         ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesID, false, versionOpenJsonNode);
@@ -567,7 +567,7 @@ class SubsetsControllerV2Test {
 
         JsonNode seriesJsonNode = readJsonFile(series_1_0);
         String seriesId = seriesJsonNode.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(seriesJsonNode);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, seriesJsonNode);
         JsonNode getSeriesJsonNode = postSeriesRE.getBody();
 
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
@@ -586,7 +586,7 @@ class SubsetsControllerV2Test {
 
         JsonNode seriesJsonNode = readJsonFile(series_1_0_invalid_id);
         String seriesId = seriesJsonNode.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(seriesJsonNode);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, seriesJsonNode);
         assertEquals(HttpStatus.BAD_REQUEST, postSeriesRE.getStatusCode());
         System.out.println("Supposedly invalid series ID: "+seriesId);
     }
@@ -597,9 +597,9 @@ class SubsetsControllerV2Test {
 
         JsonNode seriesJsonNode = readJsonFile(series_1_0);
         JsonNode seriesJsonNode2 = readJsonFile(series_1_0);
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(seriesJsonNode);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, seriesJsonNode);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
-        ResponseEntity<JsonNode> postSeriesRE2 = instance.postSubsetSeries(seriesJsonNode2);
+        ResponseEntity<JsonNode> postSeriesRE2 = instance.postSubsetSeries(false, seriesJsonNode2);
         assertEquals(HttpStatus.BAD_REQUEST, postSeriesRE2.getStatusCode());
     }
 
@@ -609,7 +609,7 @@ class SubsetsControllerV2Test {
 
         JsonNode seriesJsonNode = readJsonFile(series_1_0);
         String seriesId = seriesJsonNode.get(Field.ID).asText();
-        ResponseEntity<JsonNode> putSeriesRE = instance.putSubsetSeries(seriesId, seriesJsonNode);
+        ResponseEntity<JsonNode> putSeriesRE = instance.putSubsetSeries(seriesId, false, seriesJsonNode);
         assertEquals(HttpStatus.BAD_REQUEST, putSeriesRE.getStatusCode());
     }
 
@@ -619,7 +619,7 @@ class SubsetsControllerV2Test {
 
         JsonNode seriesJsonNode = readJsonFile(series_1_0);
         String seriesID = seriesJsonNode.get(Field.ID).asText();
-        instance.postSubsetSeries(seriesJsonNode);
+        instance.postSubsetSeries(false, seriesJsonNode);
 
         JsonNode versionOpenJsonNode = readJsonFile(version_1_0_1_open);
         ResponseEntity<JsonNode> putVersionRE = instance.putSubsetVersion(seriesID, "1", false, versionOpenJsonNode);
@@ -632,7 +632,7 @@ class SubsetsControllerV2Test {
 
         JsonNode seriesJsonNode = readJsonFile(series_1_0);
         String seriesID = seriesJsonNode.get(Field.ID).asText();
-        instance.postSubsetSeries(seriesJsonNode);
+        instance.postSubsetSeries(false, seriesJsonNode);
 
         JsonNode versionDraftJsonNode = readJsonFile(version_1_0_1);
         ResponseEntity<JsonNode> postDraftVersionRE = instance.postSubsetVersion(seriesID, false, versionDraftJsonNode);
@@ -678,7 +678,7 @@ class SubsetsControllerV2Test {
         SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
@@ -720,7 +720,7 @@ class SubsetsControllerV2Test {
         SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version_2_0_2 = readJsonFile(this.version_2_0_2);
@@ -772,7 +772,7 @@ class SubsetsControllerV2Test {
         SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1_open);
@@ -818,7 +818,7 @@ class SubsetsControllerV2Test {
 
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         ResponseEntity<JsonNode> getVersionRE = instance.getVersion(seriesId, "1");
@@ -834,7 +834,7 @@ class SubsetsControllerV2Test {
 
         JsonNode series = readJsonFile(series_2_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version202 = readJsonFile(version_2_0_2);
@@ -853,7 +853,7 @@ class SubsetsControllerV2Test {
 
         JsonNode series = readJsonFile(series_2_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version201 = readJsonFile(version_2_0_1);
@@ -888,7 +888,7 @@ class SubsetsControllerV2Test {
 
         JsonNode series = readJsonFile(series_2_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version203_overlap = readJsonFile(version_2_0_3_overlapping_date);
@@ -912,7 +912,7 @@ class SubsetsControllerV2Test {
 
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionDraft = readJsonFile(version_1_0_1_nocodes_draft);
@@ -959,7 +959,7 @@ class SubsetsControllerV2Test {
 
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionDraft = readJsonFile(version_1_0_1);
@@ -983,7 +983,7 @@ class SubsetsControllerV2Test {
 
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries( false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionDraft = readJsonFile(version_1_0_1);
@@ -1008,7 +1008,7 @@ class SubsetsControllerV2Test {
 
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionDraft = readJsonFile(version_1_0_1);
@@ -1033,7 +1033,7 @@ class SubsetsControllerV2Test {
 
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionDraft = readJsonFile(version_1_0_1);
@@ -1058,7 +1058,7 @@ class SubsetsControllerV2Test {
 
         JsonNode series = readJsonFile(series_2_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version201validUntil = readJsonFile(version_2_0_1);
@@ -1086,7 +1086,7 @@ class SubsetsControllerV2Test {
 
         JsonNode series = readJsonFile(series_2_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version201validUntil = readJsonFile(version_2_0_1);
@@ -1114,7 +1114,7 @@ class SubsetsControllerV2Test {
 
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
-        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(series);
+        ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version201validUntil = readJsonFile(version_1_0_1);

--- a/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
@@ -600,6 +600,12 @@ class SubsetsControllerV2Test {
 
         instance.deleteSeriesById(seriesId);
 
+        try {
+            Thread.sleep(50); // To make sure creation is completed before deletion is attempted
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
         ResponseEntity<JsonNode> getSubsetWhenItShouldNotExistRE = instance.getSubsetSeriesByID(seriesId, false);
         assertEquals(HttpStatus.NOT_FOUND, getSubsetWhenItShouldNotExistRE.getStatusCode());
 

--- a/src/test/resources/series_examples/series_1_extra_field.json
+++ b/src/test/resources/series_examples/series_1_extra_field.json
@@ -1,0 +1,17 @@
+{
+  "id":"UID_for_dette_uttrekket_1",
+  "description": [
+    {"languageCode":"nb", "languageText":"tekst på norsk bokmål"},
+    {"languageCode":"en", "languageText":"text in english"}
+  ],
+  "name": [
+    {"languageCode":"nb", "languageText":"fullt navn på norsk bokmål"},
+    {"languageCode":"en", "languageText":"full name in english"}
+  ],
+  "administrativeDetails": [
+    {"administrativeDetailType":"DEFAULTLANGUAGE", "values":["nb"]}
+  ],
+  "owningSection":"700 it",
+  "classificationFamily":"Some Family",
+  "extraFieldInSeries": "This field is not described in the schema for series"
+}

--- a/src/test/resources/version_examples/version_1_extra_field.json
+++ b/src/test/resources/version_examples/version_1_extra_field.json
@@ -1,0 +1,21 @@
+{
+  "validFrom":"2020-10-19",
+  "validUntil":"2021-10-19",
+  "administrativeStatus":"DRAFT",
+  "extraField": "extra field and value that does not belong in the schema",
+  "codes":[
+    {
+      "classificationId": "131",
+      "code": "1144",
+      "rank": "1",
+      "level": "1",
+      "name": "Kvitsøy",
+      "validFromInRequestedRange": "2020-10-19",
+      "validToInRequestedRange": "2021-10-19"
+    }
+  ],
+  "versionRationale": [
+    {"languageCode":"nb", "languageText":"versjon rasjonale på norsk bokmål"},
+    {"languageCode":"en", "languageText":"version rationale in english"}
+  ]
+}

--- a/src/test/resources/version_examples/version_1_extra_field_in_code.json
+++ b/src/test/resources/version_examples/version_1_extra_field_in_code.json
@@ -1,0 +1,21 @@
+{
+  "validFrom":"2020-10-19",
+  "validUntil":"2021-10-19",
+  "administrativeStatus":"DRAFT",
+  "codes":[
+    {
+      "classificationId": "131",
+      "code": "1144",
+      "rank": "1",
+      "level": "1",
+      "name": "Kvitsøy",
+      "validFromInRequestedRange": "2020-10-19",
+      "validToInRequestedRange": "2021-10-19",
+      "extraFieldInCode": "This is an extra field that does not belong in the code schema"
+    }
+  ],
+  "versionRationale": [
+    {"languageCode":"nb", "languageText":"versjon rasjonale på norsk bokmål"},
+    {"languageCode":"en", "languageText":"version rationale in english"}
+  ]
+}


### PR DESCRIPTION
We allow that if a series, version or code that is PUT or POSTed with contains fields outside the definition, those can be automatically ignored by using this request parameter:

`?ignoreSuperfluousFields=true`

The default value of the parameter is false, which means that unless you use it and set it to _true_, you will get a BAD REQUEST response when sending requests with fields that are not in the schema.