### PR TITLE
language parameter for return from POST/PUT requests

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -329,7 +329,11 @@ public class SubsetsControllerV2 {
     }
 
     @PostMapping(value = "/v2/auth/subsets/{seriesId}/versions", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<JsonNode> postSubsetVersion(@PathVariable("seriesId") String seriesId, @RequestParam(defaultValue = "false") boolean ignoreSuperfluousFields, @RequestBody JsonNode version) {
+    public ResponseEntity<JsonNode> postSubsetVersion(
+            @PathVariable("seriesId") String seriesId,
+            @RequestParam(defaultValue = "false") boolean ignoreSuperfluousFields,
+            @RequestBody JsonNode version,
+            @RequestParam(defaultValue = "all") String language) {
         LOG.info("POST request to create a version of series "+seriesId);
         if (!Utils.isClean(seriesId))
             return ErrorHandler.illegalID(LOG);
@@ -458,6 +462,8 @@ public class SubsetsControllerV2 {
 
         if (ldsPostRE.getStatusCode().equals(CREATED)) {
             LOG.debug("Successfully POSTed version nr "+versionUUID+" of subset series "+seriesId+" to LDS");
+            //TODO: If language param is set to nb/nn/en, then return codes in that language only
+            editableVersion = setCodeNameToSingleLanguage(editableVersion, language);
             return new ResponseEntity<>(editableVersion, CREATED);
         } else
             return ldsPostRE;

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -77,7 +77,7 @@ public class SubsetsControllerV2 {
      * @param subsetSeriesJson
      * @return
      */
-    @PostMapping("/v2/auth/subsets")
+    @PostMapping("/v2/subsets")
     public ResponseEntity<JsonNode> postSubsetSeries(@RequestParam(defaultValue = "false") boolean ignoreSuperfluousFields, @RequestBody JsonNode subsetSeriesJson) {
         metricsService.incrementPOSTCounter();
         LOG.info("POST subset series received. Checking body . . .");
@@ -169,7 +169,7 @@ public class SubsetsControllerV2 {
      * @param newEditionOfSeries
      * @return
      */
-    @PutMapping(value = "/v2/auth/subsets/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/v2/subsets/{id}", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<JsonNode> putSubsetSeries(@PathVariable("id") String seriesId, @RequestParam(defaultValue = "false") boolean ignoreSuperfluousFields, @RequestBody JsonNode newEditionOfSeries) {
         metricsService.incrementPUTCounter();
         LOG.info("PUT subset series with id "+seriesId);
@@ -247,7 +247,7 @@ public class SubsetsControllerV2 {
      * @param putVersion
      * @return
      */
-    @PutMapping(value = "/v2/auth/subsets/{seriesId}/versions/{versionUID}", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PutMapping(value = "/v2/subsets/{seriesId}/versions/{versionUID}", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<JsonNode> putSubsetVersion(
             @PathVariable("seriesId") String seriesId,
             @PathVariable("versionUID") String versionUID,
@@ -335,7 +335,7 @@ public class SubsetsControllerV2 {
         return editVersionRE;
     }
 
-    @PostMapping(value = "/v2/auth/subsets/{seriesId}/versions", consumes = MediaType.APPLICATION_JSON_VALUE)
+    @PostMapping(value = "/v2/subsets/{seriesId}/versions", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<JsonNode> postSubsetVersion(
             @PathVariable("seriesId") String seriesId,
             @RequestParam(defaultValue = "false") boolean ignoreSuperfluousFields,
@@ -782,16 +782,16 @@ public class SubsetsControllerV2 {
         return new LDSFacade().getSubsetSeriesSchema();
     }
 
-    @DeleteMapping("/v2/auth/subsets")
+    @DeleteMapping("/v2/subsets")
     void deleteAllSeries(){
         new LDSFacade().deleteAllSubsetSeries();
     }
-    @DeleteMapping("/v2/auth/subsets/{id}")
+    @DeleteMapping("/v2/subsets/{id}")
     void deleteSeriesById(@PathVariable("id") String id){
         new LDSFacade().deleteSubsetSeries(id);
     }
 
-    @DeleteMapping("/v2/auth/subsets/{id}/versions/{versionId}")
+    @DeleteMapping("/v2/subsets/{id}/versions/{versionId}")
     void deleteVersionById(@PathVariable("id") String id, @PathVariable("versionId") String versionId){
         LOG.info("Deleting version "+versionId+" from series "+id);
         String[] versionIdSplitUnderscore = versionId.split("_");

--- a/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
@@ -137,7 +137,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionWithExtraField = readJsonFile(version_1_extra_field);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionWithExtraField);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionWithExtraField, "all");
         assertEquals(HttpStatus.BAD_REQUEST, postVersionRE.getStatusCode());
     }
 
@@ -151,7 +151,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionWithExtraField = readJsonFile(version_1_extra_field);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, true, versionWithExtraField);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, true, versionWithExtraField, "all");
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
     }
 
@@ -164,7 +164,7 @@ class SubsetsControllerV2Test {
         ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version, "all");
         String versionId = postVersionRE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode versionWithExtraField = readJsonFile(version_1_extra_field);
@@ -181,7 +181,7 @@ class SubsetsControllerV2Test {
         ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version, "all");
         String versionId = postVersionRE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode versionWithExtraField = readJsonFile(version_1_extra_field);
@@ -199,7 +199,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionWithExtraField = readJsonFile(version_1_extra_field_in_code);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionWithExtraField);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionWithExtraField, "all");
         assertEquals(HttpStatus.BAD_REQUEST, postVersionRE.getStatusCode());
     }
 
@@ -213,7 +213,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionWithExtraField = readJsonFile(version_1_extra_field_in_code);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, true, versionWithExtraField);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, true, versionWithExtraField, "all");
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
     }
 
@@ -226,7 +226,7 @@ class SubsetsControllerV2Test {
         ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version, "all");
         String versionId = postVersionRE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode versionWithExtraField = readJsonFile(version_1_extra_field_in_code);
@@ -243,7 +243,7 @@ class SubsetsControllerV2Test {
         ResponseEntity<JsonNode> postSeriesRE = instance.postSubsetSeries(false, series);
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version, "all");
         String versionId = postVersionRE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode versionWithExtraField = readJsonFile(version_1_extra_field_in_code);
@@ -309,7 +309,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version, "all");
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
@@ -356,7 +356,7 @@ class SubsetsControllerV2Test {
         assertEquals(originalNbDescription, newNbDescription);
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version, "all");
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
@@ -394,7 +394,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version, "all");
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
         String versionUID = postVersionRE.getBody().get(Field.VERSION_ID).asText();
@@ -417,7 +417,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version, "all");
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
         try {
             Thread.sleep(100); //To make sure the resource is available from LDS before we GET it
@@ -444,7 +444,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version, "all");
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
         String versionUID1 = postVersionRE.getBody().get(Field.VERSION_ID).asText();
@@ -469,7 +469,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version, "all");
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
         String versionUID1 = postVersionRE.getBody().get(Field.VERSION_ID).asText();
@@ -496,7 +496,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionNoCodesDraft = readJsonFile(version_1_0_1_nocodes_draft);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionNoCodesDraft);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionNoCodesDraft, "all");
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
         String versionUID1 = postVersionRE.getBody().get(Field.VERSION_ID).asText();
 
@@ -514,7 +514,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionNoCodesDraft = readJsonFile(version_1_0_1_nocodes_open);
-        ResponseEntity<JsonNode> postResponseEntity = instance.postSubsetVersion(seriesId, false, versionNoCodesDraft);
+        ResponseEntity<JsonNode> postResponseEntity = instance.postSubsetVersion(seriesId, false, versionNoCodesDraft, "all");
         assertEquals(HttpStatus.BAD_REQUEST, postResponseEntity.getStatusCode());
         System.out.println(postResponseEntity.getBody().toPrettyString());
     }
@@ -529,7 +529,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version, "all");
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
         String versionUID1 = postVersionRE.getBody().get(Field.VERSION_ID).asText();
@@ -577,7 +577,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version, "all");
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
         String versionUID1 = postVersionRE.getBody().get(Field.VERSION_ID).asText();
@@ -631,7 +631,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version, "all");
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
         String versionUID1 = postVersionRE.getBody().get(Field.VERSION_ID).asText();
@@ -651,7 +651,7 @@ class SubsetsControllerV2Test {
         }
 
         JsonNode version2 = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersion2RE = instance.postSubsetVersion(seriesId, false, version2);
+        ResponseEntity<JsonNode> postVersion2RE = instance.postSubsetVersion(seriesId, false, version2, "all");
         assertTrue(postVersion2RE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersion2RE.getStatusCode());
         String versionUID2 = postVersion2RE.getBody().get(Field.VERSION_ID).asText();
@@ -716,7 +716,7 @@ class SubsetsControllerV2Test {
         String seriesID = seriesJsonNode.get(Field.ID).asText();
 
         JsonNode versionJsonNode = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesID, false, versionJsonNode);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesID, false, versionJsonNode, "all");
         String versionUID = postVersionRE.getBody().get(Field.VERSION_ID).asText();
         JsonNode retrievedSubsetSeries = instance.getSubsetSeriesByID(seriesID, false, "all").getBody();
         assertTrue(retrievedSubsetSeries.has(Field.LAST_MODIFIED));
@@ -738,7 +738,7 @@ class SubsetsControllerV2Test {
         instance.postSubsetSeries(false, seriesJsonNode);
 
         JsonNode versionOpenJsonNode = readJsonFile(version_1_0_1_open);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesID, false, versionOpenJsonNode);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesID, false, versionOpenJsonNode, "all");
         String versionUID = postVersionRE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode versionDraftJsonNode = readJsonFile(version_1_0_1);
@@ -821,7 +821,7 @@ class SubsetsControllerV2Test {
         instance.postSubsetSeries(false, seriesJsonNode);
 
         JsonNode versionDraftJsonNode = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postDraftVersionRE = instance.postSubsetVersion(seriesID, false, versionDraftJsonNode);
+        ResponseEntity<JsonNode> postDraftVersionRE = instance.postSubsetVersion(seriesID, false, versionDraftJsonNode, "all");
         String lastMod1 = postDraftVersionRE.getBody().get(Field.LAST_MODIFIED).asText();
         String versionUID = postDraftVersionRE.getBody().get(Field.VERSION_ID).asText();
         try {
@@ -868,7 +868,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version, "all");
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
@@ -881,7 +881,7 @@ class SubsetsControllerV2Test {
         }
 
         JsonNode version1_0_1_1 = readJsonFile(version_1_0_1_1);
-        ResponseEntity<JsonNode> putVersionRE = instance.postSubsetVersion(seriesId, false, version1_0_1_1);
+        ResponseEntity<JsonNode> putVersionRE = instance.postSubsetVersion(seriesId, false, version1_0_1_1, "all");
         assertEquals(HttpStatus.CREATED, putVersionRE.getStatusCode());
 
         try {
@@ -910,7 +910,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version_2_0_2 = readJsonFile(this.version_2_0_2);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version_2_0_2);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version_2_0_2, "all");
         String version202_uid = postVersionRE.getBody().get(Field.VERSION_ID).asText();
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
@@ -924,7 +924,7 @@ class SubsetsControllerV2Test {
         }
 
         JsonNode version_2_0_3 = readJsonFile(this.version_2_0_3);
-        ResponseEntity<JsonNode> putVersionRE = instance.postSubsetVersion(seriesId, false, version_2_0_3);
+        ResponseEntity<JsonNode> putVersionRE = instance.postSubsetVersion(seriesId, false, version_2_0_3, "all");
         assertEquals(HttpStatus.CREATED, putVersionRE.getStatusCode());
 
         try {
@@ -962,7 +962,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1_open);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version, "all");
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
@@ -972,7 +972,7 @@ class SubsetsControllerV2Test {
             e.printStackTrace();
         }
 
-        ResponseEntity<JsonNode> postVersionRE2 = instance.postSubsetVersion(seriesId, false, version);
+        ResponseEntity<JsonNode> postVersionRE2 = instance.postSubsetVersion(seriesId, false, version, "all");
         assertEquals(HttpStatus.BAD_REQUEST, postVersionRE2.getStatusCode());
     }
 
@@ -986,7 +986,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version = readJsonFile(version_1_0_1_open);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version, "all");
         assertTrue(postVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
@@ -998,7 +998,7 @@ class SubsetsControllerV2Test {
 
         JsonNode version2 = readJsonFile(version_1_0_1);
 
-        ResponseEntity<JsonNode> postVersionRE2 = instance.postSubsetVersion(seriesId, false, version2);
+        ResponseEntity<JsonNode> postVersionRE2 = instance.postSubsetVersion(seriesId, false, version2, "all");
         assertEquals(HttpStatus.CREATED, postVersionRE2.getStatusCode());
     }
 
@@ -1050,7 +1050,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version202 = readJsonFile(version_2_0_2);
-        ResponseEntity<JsonNode> postVersion2RE = instance.postSubsetVersion(seriesId, false, version202);
+        ResponseEntity<JsonNode> postVersion2RE = instance.postSubsetVersion(seriesId, false, version202, "all");
         assertEquals(HttpStatus.CREATED, postVersion2RE.getStatusCode());
         String version2ID = postVersion2RE.getBody().get(Field.VERSION_ID).asText();
 
@@ -1069,11 +1069,11 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version201 = readJsonFile(version_2_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version201);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, version201, "all");
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
         JsonNode version202 = readJsonFile(version_2_0_2);
-        ResponseEntity<JsonNode> postVersion2RE = instance.postSubsetVersion(seriesId, false, version202);
+        ResponseEntity<JsonNode> postVersion2RE = instance.postSubsetVersion(seriesId, false, version202, "all");
         assertEquals(HttpStatus.CREATED, postVersion2RE.getStatusCode());
         String version2ID = postVersion2RE.getBody().get(Field.VERSION_ID).asText();
 
@@ -1086,11 +1086,11 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.OK, putVersion2validUntilRE.getStatusCode());
 
         JsonNode version203_overlap = readJsonFile(version_2_0_3_overlapping_date);
-        ResponseEntity<JsonNode> postVersion3RE = instance.postSubsetVersion(seriesId, false, version203_overlap);
+        ResponseEntity<JsonNode> postVersion3RE = instance.postSubsetVersion(seriesId, false, version203_overlap, "all");
         assertEquals(HttpStatus.BAD_REQUEST, postVersion3RE.getStatusCode());
 
         JsonNode version203_no_overlap = readJsonFile(version_2_0_3);
-        postVersion3RE = instance.postSubsetVersion(seriesId, false, version203_no_overlap);
+        postVersion3RE = instance.postSubsetVersion(seriesId, false, version203_no_overlap, "all");
         assertEquals(HttpStatus.CREATED, postVersion3RE.getStatusCode());
     }
 
@@ -1104,7 +1104,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version203_overlap = readJsonFile(version_2_0_3_overlapping_date);
-        ResponseEntity<JsonNode> postVersion3RE = instance.postSubsetVersion(seriesId, false, version203_overlap);
+        ResponseEntity<JsonNode> postVersion3RE = instance.postSubsetVersion(seriesId, false, version203_overlap, "all");
         assertEquals(HttpStatus.CREATED, postVersion3RE.getStatusCode());
 
         try {
@@ -1114,7 +1114,7 @@ class SubsetsControllerV2Test {
         }
 
         JsonNode version202validUntil = readJsonFile(version_2_0_2_validUntil);
-        ResponseEntity<JsonNode> postVersion2validUntilRE = instance.postSubsetVersion(seriesId, false, version202validUntil);
+        ResponseEntity<JsonNode> postVersion2validUntilRE = instance.postSubsetVersion(seriesId, false, version202validUntil, "all");
         assertEquals(HttpStatus.BAD_REQUEST, postVersion2validUntilRE.getStatusCode());
     }
 
@@ -1128,7 +1128,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionDraft = readJsonFile(version_1_0_1_nocodes_draft);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionDraft);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionDraft, "all");
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
         try {
@@ -1138,7 +1138,7 @@ class SubsetsControllerV2Test {
         }
 
         JsonNode versionOpen = readJsonFile(version_1_0_1_open);
-        ResponseEntity<JsonNode> postVersionOpenRE = instance.postSubsetVersion(seriesId, false, versionOpen);
+        ResponseEntity<JsonNode> postVersionOpenRE = instance.postSubsetVersion(seriesId, false, versionOpen, "all");
         assertEquals(HttpStatus.CREATED, postVersionOpenRE.getStatusCode());
 
         try {
@@ -1175,7 +1175,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionDraft = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionDraft);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionDraft, "all");
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
         try {
@@ -1185,7 +1185,7 @@ class SubsetsControllerV2Test {
         }
 
         JsonNode versionDraft2 = readJsonFile(version_1_0_1_1);
-        ResponseEntity<JsonNode> postVersionRE2 = instance.postSubsetVersion(seriesId, false, versionDraft2);
+        ResponseEntity<JsonNode> postVersionRE2 = instance.postSubsetVersion(seriesId, false, versionDraft2, "all");
         assertEquals(HttpStatus.CREATED, postVersionRE2.getStatusCode());
     }
 
@@ -1199,7 +1199,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionDraft = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionDraft);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionDraft, "all");
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
         try {
@@ -1224,7 +1224,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionDraft = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionDraft);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionDraft, "all");
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
         try {
@@ -1249,7 +1249,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode versionDraft = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionDraft);
+        ResponseEntity<JsonNode> postVersionRE = instance.postSubsetVersion(seriesId, false, versionDraft, "all");
         assertEquals(HttpStatus.CREATED, postVersionRE.getStatusCode());
 
         try {
@@ -1274,11 +1274,11 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version201validUntil = readJsonFile(version_2_0_1);
-        ResponseEntity<JsonNode> postVersion1validUntilRE = instance.postSubsetVersion(seriesId, false, version201validUntil);
+        ResponseEntity<JsonNode> postVersion1validUntilRE = instance.postSubsetVersion(seriesId, false, version201validUntil, "all");
         assertEquals(HttpStatus.CREATED, postVersion1validUntilRE.getStatusCode());
 
         JsonNode version202validUntil = readJsonFile(version_2_0_2);
-        ResponseEntity<JsonNode> postVersion2validUntilRE = instance.postSubsetVersion(seriesId, false, version202validUntil);
+        ResponseEntity<JsonNode> postVersion2validUntilRE = instance.postSubsetVersion(seriesId, false, version202validUntil, "all");
         assertEquals(HttpStatus.CREATED, postVersion2validUntilRE.getStatusCode());
 
         try {
@@ -1304,7 +1304,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version202validUntil = readJsonFile(version_2_0_2);
-        ResponseEntity<JsonNode> postVersion2validUntilRE = instance.postSubsetVersion(seriesId, false, version202validUntil);
+        ResponseEntity<JsonNode> postVersion2validUntilRE = instance.postSubsetVersion(seriesId, false, version202validUntil, "all");
         assertEquals(HttpStatus.CREATED, postVersion2validUntilRE.getStatusCode());
 
         try {
@@ -1330,7 +1330,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version202validUntil = readJsonFile(version_2_0_2);
-        ResponseEntity<JsonNode> postVersion2validUntilRE = instance.postSubsetVersion(seriesId, false, version202validUntil);
+        ResponseEntity<JsonNode> postVersion2validUntilRE = instance.postSubsetVersion(seriesId, false, version202validUntil, "all");
         assertEquals(HttpStatus.CREATED, postVersion2validUntilRE.getStatusCode());
 
         try {
@@ -1358,11 +1358,11 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version201validUntil = readJsonFile(version_2_0_1);
-        ResponseEntity<JsonNode> postVersion1validUntilRE = instance.postSubsetVersion(seriesId, false, version201validUntil);
+        ResponseEntity<JsonNode> postVersion1validUntilRE = instance.postSubsetVersion(seriesId, false, version201validUntil, "all");
         assertEquals(HttpStatus.CREATED, postVersion1validUntilRE.getStatusCode());
 
         JsonNode version202validUntil = readJsonFile(version_2_0_2_validUntil);
-        ResponseEntity<JsonNode> postVersion2validUntilRE = instance.postSubsetVersion(seriesId, false, version202validUntil);
+        ResponseEntity<JsonNode> postVersion2validUntilRE = instance.postSubsetVersion(seriesId, false, version202validUntil, "all");
         assertEquals(HttpStatus.CREATED, postVersion2validUntilRE.getStatusCode());
 
         try {
@@ -1389,7 +1389,7 @@ class SubsetsControllerV2Test {
         assertEquals(HttpStatus.CREATED, postSeriesRE.getStatusCode());
 
         JsonNode version201validUntil = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> postVersion1validUntilRE = instance.postSubsetVersion(seriesId, false, version201validUntil);
+        ResponseEntity<JsonNode> postVersion1validUntilRE = instance.postSubsetVersion(seriesId, false, version201validUntil, "all");
         assertEquals(HttpStatus.CREATED, postVersion1validUntilRE.getStatusCode());
 
         try {

--- a/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
@@ -168,7 +168,7 @@ class SubsetsControllerV2Test {
         String versionId = postVersionRE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode versionWithExtraField = readJsonFile(version_1_extra_field);
-        ResponseEntity<JsonNode> putVersionRE = instance.putSubsetVersion(seriesId, versionId, false, versionWithExtraField);
+        ResponseEntity<JsonNode> putVersionRE = instance.putSubsetVersion(seriesId, versionId, false,  "all", versionWithExtraField);
         assertEquals(HttpStatus.BAD_REQUEST, putVersionRE.getStatusCode());
     }
 
@@ -185,7 +185,7 @@ class SubsetsControllerV2Test {
         String versionId = postVersionRE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode versionWithExtraField = readJsonFile(version_1_extra_field);
-        ResponseEntity<JsonNode> putVersionRE = instance.putSubsetVersion(seriesId, versionId, true, versionWithExtraField);
+        ResponseEntity<JsonNode> putVersionRE = instance.putSubsetVersion(seriesId, versionId, true, "all", versionWithExtraField);
         assertEquals(HttpStatus.OK, putVersionRE.getStatusCode());
     }
 
@@ -230,7 +230,7 @@ class SubsetsControllerV2Test {
         String versionId = postVersionRE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode versionWithExtraField = readJsonFile(version_1_extra_field_in_code);
-        ResponseEntity<JsonNode> putVersionRE = instance.putSubsetVersion(seriesId, versionId, false, versionWithExtraField);
+        ResponseEntity<JsonNode> putVersionRE = instance.putSubsetVersion(seriesId, versionId, false, "all", versionWithExtraField);
         assertEquals(HttpStatus.BAD_REQUEST, putVersionRE.getStatusCode());
     }
 
@@ -247,7 +247,7 @@ class SubsetsControllerV2Test {
         String versionId = postVersionRE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode versionWithExtraField = readJsonFile(version_1_extra_field_in_code);
-        ResponseEntity<JsonNode> putVersionRE = instance.putSubsetVersion(seriesId, versionId, true, versionWithExtraField);
+        ResponseEntity<JsonNode> putVersionRE = instance.putSubsetVersion(seriesId, versionId, true, "all", versionWithExtraField);
         assertEquals(HttpStatus.OK, putVersionRE.getStatusCode());
     }
 
@@ -400,7 +400,7 @@ class SubsetsControllerV2Test {
         String versionUID = postVersionRE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode versionOpen = readJsonFile(version_1_0_1_open);
-        ResponseEntity<JsonNode> putOpenVersionRE = instance.putSubsetVersion(seriesId, versionUID, false, versionOpen);
+        ResponseEntity<JsonNode> putOpenVersionRE = instance.putSubsetVersion(seriesId, versionUID, false, "all", versionOpen);
         assertTrue(putOpenVersionRE.getStatusCode().is2xxSuccessful());
         assertEquals(HttpStatus.OK, putOpenVersionRE.getStatusCode());
     }
@@ -475,7 +475,7 @@ class SubsetsControllerV2Test {
         String versionUID1 = postVersionRE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode version1_0_1_1 = readJsonFile(version_1_0_1_1);
-        ResponseEntity<JsonNode> putVersionRE = instance.putSubsetVersion(seriesId, versionUID1, false, version1_0_1_1);
+        ResponseEntity<JsonNode> putVersionRE = instance.putSubsetVersion(seriesId, versionUID1, false, "all", version1_0_1_1);
         assertEquals(HttpStatus.OK, putVersionRE.getStatusCode());
 
         ResponseEntity<JsonNode> getVersionRE = instance.getVersion(seriesId, versionUID1, "all");
@@ -501,7 +501,7 @@ class SubsetsControllerV2Test {
         String versionUID1 = postVersionRE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode versionNoCodesOpen = readJsonFile(version_1_0_1_nocodes_open);
-        ResponseEntity<JsonNode> putResponseEntity = instance.putSubsetVersion(seriesId, versionUID1, false, versionNoCodesOpen);
+        ResponseEntity<JsonNode> putResponseEntity = instance.putSubsetVersion(seriesId, versionUID1, false, "all", versionNoCodesOpen);
         assertEquals(HttpStatus.BAD_REQUEST, putResponseEntity.getStatusCode()); // 0 codes is not allowed in published subset
     }
 
@@ -742,7 +742,7 @@ class SubsetsControllerV2Test {
         String versionUID = postVersionRE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode versionDraftJsonNode = readJsonFile(version_1_0_1);
-        ResponseEntity<JsonNode> putDraftAfterOpenRE = instance.putSubsetVersion(seriesID, versionUID, false, versionDraftJsonNode);
+        ResponseEntity<JsonNode> putDraftAfterOpenRE = instance.putSubsetVersion(seriesID, versionUID, false, "all", versionDraftJsonNode);
 
         assertEquals(HttpStatus.BAD_REQUEST, putDraftAfterOpenRE.getStatusCode());
     }
@@ -808,7 +808,7 @@ class SubsetsControllerV2Test {
         instance.postSubsetSeries(false, seriesJsonNode);
 
         JsonNode versionOpenJsonNode = readJsonFile(version_1_0_1_open);
-        ResponseEntity<JsonNode> putVersionRE = instance.putSubsetVersion(seriesID, "1", false, versionOpenJsonNode);
+        ResponseEntity<JsonNode> putVersionRE = instance.putSubsetVersion(seriesID, "1", false, "all", versionOpenJsonNode);
         assertEquals(HttpStatus.BAD_REQUEST, putVersionRE.getStatusCode());
     }
 
@@ -840,7 +840,7 @@ class SubsetsControllerV2Test {
         }
 
         JsonNode versionOpenJsonNode = readJsonFile(version_1_0_1_open);
-        ResponseEntity<JsonNode> putOpenVersionRE = instance.putSubsetVersion(seriesID, versionUID, false, versionOpenJsonNode);
+        ResponseEntity<JsonNode> putOpenVersionRE = instance.putSubsetVersion(seriesID, versionUID, false, "all", versionOpenJsonNode);
         assertEquals(HttpStatus.OK, putOpenVersionRE.getStatusCode());
         String lastMod2 = putOpenVersionRE.getBody().get(Field.LAST_MODIFIED).asText();
 
@@ -1055,7 +1055,7 @@ class SubsetsControllerV2Test {
         String version2ID = postVersion2RE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode version202validUntil = readJsonFile(version_2_0_2_validUntil);
-        ResponseEntity<JsonNode> putVersion2validUntilRE = instance.putSubsetVersion(seriesId, version2ID, false, version202validUntil);
+        ResponseEntity<JsonNode> putVersion2validUntilRE = instance.putSubsetVersion(seriesId, version2ID, false, "all", version202validUntil);
         assertEquals(HttpStatus.OK, putVersion2validUntilRE.getStatusCode());
     }
 
@@ -1078,7 +1078,7 @@ class SubsetsControllerV2Test {
         String version2ID = postVersion2RE.getBody().get(Field.VERSION_ID).asText();
 
         JsonNode version202validUntil = readJsonFile(version_2_0_2_validUntil);
-        ResponseEntity<JsonNode> putVersion2validUntilRE = instance.putSubsetVersion(seriesId, version2ID, false, version202validUntil);
+        ResponseEntity<JsonNode> putVersion2validUntilRE = instance.putSubsetVersion(seriesId, version2ID, false, "all", version202validUntil);
         if (!putVersion2validUntilRE.getStatusCode().is2xxSuccessful()) {
             System.out.println("*** BODY ***");
             System.out.println(putVersion2validUntilRE.getBody().toPrettyString());

--- a/src/test/resources/series_examples/series_1_0.json
+++ b/src/test/resources/series_examples/series_1_0.json
@@ -5,8 +5,8 @@
     {"languageCode":"en", "languageText":"text in english"}
   ],
   "name": [
-    {"languageCode":"nb", "languageText":"fullt navn på norsk bokmål"},
-    {"languageCode":"en", "languageText":"full name in english"}
+    {"languageCode":"nb", "languageText":"Uttrekk for test"},
+    {"languageCode":"en", "languageText":"Subset for test"}
   ],
   "administrativeDetails": [
     {"administrativeDetailType":"DEFAULTLANGUAGE", "values":["nb"]}

--- a/src/test/resources/series_examples/series_1_0_invalid_id.json
+++ b/src/test/resources/series_examples/series_1_0_invalid_id.json
@@ -5,8 +5,8 @@
     {"languageCode":"en", "languageText":"text in english"}
   ],
   "name": [
-    {"languageCode":"nb", "languageText":"fullt navn på norsk bokmål"},
-    {"languageCode":"en", "languageText":"full name in english"}
+    {"languageCode":"nb", "languageText":"Uttrekk for test"},
+    {"languageCode":"en", "languageText":"Subset for test"}
   ],
   "administrativeDetails": [
     {"administrativeDetailType":"DEFAULTLANGUAGE", "values":["nb"]}

--- a/src/test/resources/series_examples/series_1_1.json
+++ b/src/test/resources/series_examples/series_1_1.json
@@ -5,8 +5,8 @@
     {"languageCode":"en", "languageText":"v1.1 text in english"}
   ],
   "name": [
-    {"languageCode":"nb", "languageText":"v1.1 fullt navn på norsk bokmål"},
-    {"languageCode":"en", "languageText":"v1.1 full name in english"}
+    {"languageCode":"nb", "languageText":"Uttrekk for test v1.1"},
+    {"languageCode":"en", "languageText":"Subset for test v1.1"}
   ],
   "administrativeDetails": [
     {"administrativeDetailType":"DEFAULTLANGUAGE", "values":["en"]}

--- a/src/test/resources/series_examples/series_1_extra_field.json
+++ b/src/test/resources/series_examples/series_1_extra_field.json
@@ -5,8 +5,8 @@
     {"languageCode":"en", "languageText":"text in english"}
   ],
   "name": [
-    {"languageCode":"nb", "languageText":"fullt navn på norsk bokmål"},
-    {"languageCode":"en", "languageText":"full name in english"}
+    {"languageCode":"nb", "languageText":"Uttrekk for test ekstra felt"},
+    {"languageCode":"en", "languageText":"Subset for test extra field"}
   ],
   "administrativeDetails": [
     {"administrativeDetailType":"DEFAULTLANGUAGE", "values":["nb"]}

--- a/src/test/resources/series_examples/series_2_0.json
+++ b/src/test/resources/series_examples/series_2_0.json
@@ -5,8 +5,8 @@
     {"languageCode":"en", "languageText":"2 text in english"}
   ],
   "name": [
-    {"languageCode":"nb", "languageText":"2 fullt navn på norsk bokmål"},
-    {"languageCode":"en", "languageText":"2 full name in english"}
+    {"languageCode":"nb", "languageText":"Uttrekk for test"},
+    {"languageCode":"en", "languageText":"Subset for test"}
   ],
   "administrativeDetails": [
     {"administrativeDetailType":"DEFAULTLANGUAGE", "values":["en"]}


### PR DESCRIPTION
Users can now use the "language" parameter to chose the language of the name of the codes in a version in the return body of POST/PUT requests
