### PR TITLE
Tag last master image for production

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -83,6 +83,6 @@ jobs:
           imageName: $(imageName)
           repoName: $(repoName)
       - template: 'docker/docker-tag-for-production.yml@templates'
-          parameters:
-            tagToTag: 'master-$(fullSha)'
-            gcrImageName: $(imageName)
+        parameters:
+          tagToTag: 'master-$(fullSha)'
+          gcrImageName: $(imageName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,3 +82,7 @@ jobs:
         parameters:
           imageName: $(imageName)
           repoName: $(repoName)
+      - template: 'docker/docker-tag-for-production.yml@templates'
+          parameters:
+            tagToTag: 'master-$(fullSha)'
+            gcrImageName: $(imageName)


### PR DESCRIPTION
Add ['docker-tag-for-production.yml'](https://github.com/statisticsnorway/azure-pipelines-templates/blob/master/docker/docker-tag-for-production.yml) template step to end of pipeline, the way it was done [here](https://github.com/statisticsnorway/ssb-developer-guide/blob/master/docs/azure_pipeline_doc.md).

When this step is run, it should cause the pipeline to re-tag the last built image from the ´master´ branch for production.