### PR TITLE
Store code notes in subset version codes

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/Field.java
+++ b/src/main/java/no/ssb/subsetsservice/Field.java
@@ -30,4 +30,7 @@ public class Field {
     public static final String ADMINISTRATIVE_DETAIL_TYPE = "administrativeDetailType";
     public static final String DEFAULTLANGUAGE = "DEFAULTLANGUAGE";
     public static final String VALUES = "values";
+    public static final String NOTES = "notes";
+    public static final String LANGUAGE_TEXT = "languageText";
+    public static final String LANGUAGE_CODE = "languageCode";
 }

--- a/src/main/java/no/ssb/subsetsservice/Field.java
+++ b/src/main/java/no/ssb/subsetsservice/Field.java
@@ -33,4 +33,5 @@ public class Field {
     public static final String NOTES = "notes";
     public static final String LANGUAGE_TEXT = "languageText";
     public static final String LANGUAGE_CODE = "languageCode";
+    public static final String CLASSIFICATION_ITEMS = "classificationItems";
 }

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -124,6 +124,13 @@ public class Utils {
         return String.format(URN_FORMAT, classification, code);
     }
 
+    public static ObjectNode createMultilingualText(String languageCode, String languageText) {
+        ObjectNode mlT = new ObjectMapper().createObjectNode();
+        mlT.put(Field.LANGUAGE_CODE, languageCode);
+        mlT.put(Field.LANGUAGE_TEXT, languageText);
+        return mlT;
+    }
+
     public static ObjectNode addCodeVersionsToAllCodesInVersion(JsonNode subsetVersion, Logger LOG) {
         ObjectNode editableVersion = subsetVersion.deepCopy();
         LOG.debug("Finding out what classification versions the codes in the subsetVersion are used in");


### PR DESCRIPTION
Each code saved in a subset version will now contain the code notes from klass in all languages.

The notes are stored in the field "notes" as an array of MultilingualText objects. There is one MlT for each of the language codes 'en', 'nb' and 'nn'.

The corresponding LDS klass schema change has been requested in staging, [here.](https://github.com/statisticsnorway/platform-dev/pull/769) The linked PR should be merged and deployed before this PR is merged and deployed to staging. The schema change should also be made to LDS klass in prod before this is deployed in prod.