### PR TITLE
validUntil of subset version is not inclusive

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
+++ b/src/main/java/no/ssb/subsetsservice/KlassURNResolver.java
@@ -1,9 +1,6 @@
 package no.ssb.subsetsservice;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -11,9 +8,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
-
-import java.util.HashMap;
-import java.util.Map;
 
 public class KlassURNResolver {
 

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -1177,7 +1177,7 @@ public class SubsetsControllerV2 {
 
     private ResponseEntity<JsonNode> updateLatestPublishedValidUntil(ResponseEntity<JsonNode> isOverlappingValidityRE,
                                                                      JsonNode newVersion,
-                                                                     String seriesId){
+                                                                     String seriesId) {
         JsonNode isOverlapREBody = isOverlappingValidityRE.getBody();
         if (isOverlapREBody.get("existOtherPublishedVersions").asBoolean() &&
                 isOverlapREBody.get("isNewLatestVersion").asBoolean()) {

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -1092,6 +1092,11 @@ public class SubsetsControllerV2 {
                                 LOG);
 
                     if (newVersionValidUntil != null) {
+                        if (newVersionValidUntil.compareTo(oldPublishedVersionValidFrom) > 0 && newVersionValidFrom.compareTo(oldPublishedVersionValidFrom) < 0)
+                            return ErrorHandler.newHttpError(
+                                    "The new version's validUntil can not be inside the range of an existing published version when the validFrom of the new version is before the validFrom of the old published subset",
+                                    BAD_REQUEST,
+                                    LOG);
                         // Check if newVersionValidUntil of the new version is within the validity range of this old version
                         if (newVersionValidUntil.compareTo(oldPublishedVersionValidFrom) > 0 && (oldPublishedVersionValidUntil != null && newVersionValidUntil.compareTo(oldPublishedVersionValidUntil) <= 0))
                             return ErrorHandler.newHttpError(

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -1085,7 +1085,7 @@ public class SubsetsControllerV2 {
 
                     String oldPublishedVersionValidUntil = oldPublishedSubsetVersion.has(Field.VALID_UNTIL) ? oldPublishedSubsetVersion.get(Field.VALID_UNTIL).asText() : null;
 
-                    if (newVersionValidFrom.compareTo(oldPublishedVersionValidFrom) >= 0 && (oldPublishedVersionValidUntil != null && newVersionValidFrom.compareTo(oldPublishedVersionValidUntil) <= 0))
+                    if (newVersionValidFrom.compareTo(oldPublishedVersionValidFrom) >= 0 && (oldPublishedVersionValidUntil != null && newVersionValidFrom.compareTo(oldPublishedVersionValidUntil) < 0))
                         return ErrorHandler.newHttpError(
                                 "The new version's validFrom is within the closed validity range of an existing subset version. Colliding version nr: "+oldPublishedSubsetVersion.get(Field.VERSION_ID).asText(),
                                 BAD_REQUEST,

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -1104,7 +1104,7 @@ public class SubsetsControllerV2 {
                                     "If a validUntil is not set for a posted version, it must be the new latest subset series version ",
                                     BAD_REQUEST,
                                     LOG);
-                        if (oldPublishedVersionValidUntil != null && oldPublishedVersionValidUntil.compareTo(newVersionValidFrom) >= 0)
+                        if (oldPublishedVersionValidUntil != null && oldPublishedVersionValidUntil.compareTo(newVersionValidFrom) > 0)
                             return ErrorHandler.newHttpError(
                                     "The new latest version's validFrom must be after the previous versions validUntil, if the previous version has an explicit validUntil",
                                     BAD_REQUEST,

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -774,7 +774,8 @@ public class SubsetsControllerV2 {
 
     /**
      * Returns all codes of the subset version that is valid on the given date.
-     * Assumes only one subset is valid on any given date, with no overlap of start/end date.
+     * OLD: Assumes only one subset is valid on any given date, with no overlap of start/end date.
+     * NEW: (TODO) End date of versions is not inclusive. Subsets validity ranges "overlap" on that date.
      * @param id
      * @param date
      * @return
@@ -1044,8 +1045,8 @@ public class SubsetsControllerV2 {
     }
 
     private ResponseEntity<JsonNode> isOverlappingValidity(JsonNode editableVersion) {
-        String validFrom = editableVersion.get(Field.VALID_FROM).asText();
-        String validUntil = editableVersion.has(Field.VALID_UNTIL) ? editableVersion.get(Field.VALID_UNTIL).asText() : null;
+        String newVersionValidFrom = editableVersion.get(Field.VALID_FROM).asText();
+        String newVersionValidUntil = editableVersion.has(Field.VALID_UNTIL) ? editableVersion.get(Field.VALID_UNTIL).asText() : null;
 
         String seriesID = editableVersion.get(Field.SUBSET_ID).asText();
         ResponseEntity<JsonNode> getPublishedVersionsRE = getVersions(seriesID, true, false, "all");
@@ -1071,62 +1072,41 @@ public class SubsetsControllerV2 {
             existOtherPublishedVersions = true;
             String firstValidFrom = null;
             String lastValidFrom = null;
-            for (JsonNode versionJsonNode : publishedSubsetVersionsArrayNode) {
-                if (versionJsonNode.get(Field.ADMINISTRATIVE_STATUS).asText().equals(Field.OPEN)) { // We only care about checking against published subset versions
-                    LOG.debug("Checking version "+versionJsonNode.get(Field.SUBSET_ID).asText()+"_"+versionJsonNode.get(Field.VERSION_ID).asText()+" for overlap with the new version, since it is published.");
-                    String versionValidFrom = versionJsonNode.get(Field.VALID_FROM).asText();
-                    if (firstValidFrom == null || versionValidFrom.compareTo(firstValidFrom) < 0)
-                        firstValidFrom = versionValidFrom;
-                    if (lastValidFrom == null || versionValidFrom.compareTo(lastValidFrom) > 0) {
-                        lastValidFrom = versionValidFrom;
-                        latestPublishedVersion = versionJsonNode;
+            for (JsonNode oldPublishedSubsetVersion : publishedSubsetVersionsArrayNode) {
+                if (oldPublishedSubsetVersion.get(Field.ADMINISTRATIVE_STATUS).asText().equals(Field.OPEN)) { // We only care about checking against published subset versions
+                    LOG.debug("Checking version "+oldPublishedSubsetVersion.get(Field.SUBSET_ID).asText()+"_"+oldPublishedSubsetVersion.get(Field.VERSION_ID).asText()+" for overlap with the new version, since it is published.");
+                    String oldPublishedVersionValidFrom = oldPublishedSubsetVersion.get(Field.VALID_FROM).asText();
+                    if (firstValidFrom == null || oldPublishedVersionValidFrom.compareTo(firstValidFrom) < 0)
+                        firstValidFrom = oldPublishedVersionValidFrom;
+                    if (lastValidFrom == null || oldPublishedVersionValidFrom.compareTo(lastValidFrom) > 0) {
+                        lastValidFrom = oldPublishedVersionValidFrom;
+                        latestPublishedVersion = oldPublishedSubsetVersion;
                     }
 
-                    if (validFrom.compareTo(versionValidFrom) == 0)
+                    String oldPublishedVersionValidUntil = oldPublishedSubsetVersion.has(Field.VALID_UNTIL) ? oldPublishedSubsetVersion.get(Field.VALID_UNTIL).asText() : null;
+
+                    if (newVersionValidFrom.compareTo(oldPublishedVersionValidFrom) >= 0 && (oldPublishedVersionValidUntil != null && newVersionValidFrom.compareTo(oldPublishedVersionValidUntil) <= 0))
                         return ErrorHandler.newHttpError(
-                                "validFrom of a subsetVersion can not be the same as an existing published subset version's validFrom. Colliding version nr: "+versionJsonNode.get(Field.VERSION_ID).asText(),
+                                "The new version's validFrom is within the closed validity range of an existing subset version. Colliding version nr: "+oldPublishedSubsetVersion.get(Field.VERSION_ID).asText(),
                                 BAD_REQUEST,
                                 LOG);
 
-                    String versionValidUntil = versionJsonNode.has(Field.VALID_UNTIL) ? versionJsonNode.get(Field.VALID_UNTIL).asText() : null;
-
-                    if (validUntil != null) {
-                        // Check if validUntil of the new version is within the validity range of this old version
-                        if ((validUntil.compareTo(versionValidFrom) >= 0 && (versionValidUntil == null || validUntil.compareTo(versionValidUntil) <= 0)) ||
-                                (validFrom.compareTo(versionValidFrom) >= 0 && (versionValidUntil == null || validFrom.compareTo(versionValidUntil) <= 0))){
+                    if (newVersionValidUntil != null) {
+                        // Check if newVersionValidUntil of the new version is within the validity range of this old version
+                        if (newVersionValidUntil.compareTo(oldPublishedVersionValidFrom) > 0 && (oldPublishedVersionValidUntil != null && newVersionValidUntil.compareTo(oldPublishedVersionValidUntil) <= 0))
                             return ErrorHandler.newHttpError(
-                                    "The new version's validUntil is within the validity range of an existing subset version. Colliding version nr: "+versionJsonNode.get(Field.VERSION_ID).asText(),
+                                    "The new version's validUntil is within the closed validity range of an existing subset version. Colliding version nr: "+oldPublishedSubsetVersion.get(Field.VERSION_ID).asText(),
                                     BAD_REQUEST,
                                     LOG);
-                        }
-                    } else { // ValidUntil is null, which is ONLY allowed to be the case if the new version is supposed to be the new latest version
-                        if (versionValidFrom.compareTo(validFrom) >= 0)
+                    } else { // newVersionValidUntil is null, which is ONLY allowed to be the case if the new version is supposed to be the new latest version
+                        if (oldPublishedVersionValidFrom.compareTo(newVersionValidFrom) >= 0)
                             return ErrorHandler.newHttpError(
                                     "If a validUntil is not set for a posted version, it must be the new latest subset series version ",
                                     BAD_REQUEST,
                                     LOG);
-                        if (versionValidUntil != null && versionValidUntil.compareTo(validFrom) >= 0)
+                        if (oldPublishedVersionValidUntil != null && oldPublishedVersionValidUntil.compareTo(newVersionValidFrom) >= 0)
                             return ErrorHandler.newHttpError(
                                     "The new latest version's validFrom must be after the previous versions validUntil, if the previous version has an explicit validUntil",
-                                    BAD_REQUEST,
-                                    LOG);
-                    }
-
-                    //TODO: I think this whole block is now superfluous and already covered by the one above. But this one does not cover all the bases of the one above.
-                    if (versionValidUntil != null && validUntil != null) {
-                        if (validUntil.compareTo(versionValidUntil) <= 0 && validUntil.compareTo(versionValidFrom) >= 0)
-                            return ErrorHandler.newHttpError(
-                                    "The new version's validUntil is within the validity range of an existing subset version. Colliding version nr: "+versionJsonNode.get(Field.VERSION_ID).asText(),
-                                    BAD_REQUEST,
-                                    LOG);
-                        if (validFrom.compareTo(versionValidFrom) >= 0 && validFrom.compareTo(versionValidUntil) <= 0)
-                            return ErrorHandler.newHttpError(
-                                    "The new version's validFrom is within the validity range of an existing subset version. Colliding version nr: "+versionJsonNode.get(Field.VERSION_ID).asText(),
-                                    BAD_REQUEST,
-                                    LOG);
-                        if (validUntil.compareTo(versionValidUntil) == 0)
-                            return ErrorHandler.newHttpError(
-                                    "validUntil can not be the same as existing subset's validUntil, when they are explicit. Colliding version nr: "+versionJsonNode.get(Field.VERSION_ID).asText(),
                                     BAD_REQUEST,
                                     LOG);
                     }
@@ -1134,11 +1114,11 @@ public class SubsetsControllerV2 {
             }
             LOG.debug("Done iterating over all existing versions of the subset to check validity period overlaps");
 
-            if (firstValidFrom != null && validFrom.compareTo(firstValidFrom) >= 0 && lastValidFrom != null && validFrom.compareTo(lastValidFrom) <= 0)
+            if (firstValidFrom != null && newVersionValidFrom.compareTo(firstValidFrom) >= 0 && lastValidFrom != null && newVersionValidFrom.compareTo(lastValidFrom) <= 0)
                 return ErrorHandler.newHttpError("The validity period of a new subset must be before or after all existing versions", BAD_REQUEST, LOG);
 
-            isNewLatestVersion = lastValidFrom == null || validFrom.compareTo(lastValidFrom) > 0;
-            isNewFirstVersion = firstValidFrom == null || validFrom.compareTo(firstValidFrom) < 0;
+            isNewLatestVersion = lastValidFrom == null || newVersionValidFrom.compareTo(lastValidFrom) > 0;
+            isNewFirstVersion = firstValidFrom == null || newVersionValidFrom.compareTo(firstValidFrom) < 0;
 
 
             LOG.debug("Done processing and checking new version in relation to old versions");

--- a/src/test/resources/version_examples/version_2_0_2.json
+++ b/src/test/resources/version_examples/version_2_0_2.json
@@ -1,5 +1,5 @@
 {
-  "validFrom":"2007-01-02",
+  "validFrom":"2007-01-01",
   "administrativeStatus":"OPEN",
   "codes":[
     {
@@ -17,7 +17,7 @@
       "level": "1",
       "name": "Sortland",
       "rank": "1",
-      "validFromInRequestedRange": "2007-01-02",
+      "validFromInRequestedRange": "2007-01-01",
       "validToInRequestedRange": "2018-01-01"
     }
   ],

--- a/src/test/resources/version_examples/version_2_0_2_validUntil.json
+++ b/src/test/resources/version_examples/version_2_0_2_validUntil.json
@@ -1,5 +1,5 @@
 {
-  "validFrom":"2007-01-02",
+  "validFrom":"2007-01-01",
   "validUntil":"2020-01-02",
   "administrativeStatus":"OPEN",
   "codes":[

--- a/src/test/resources/version_examples/version_2_0_2_validUntil.json
+++ b/src/test/resources/version_examples/version_2_0_2_validUntil.json
@@ -1,6 +1,6 @@
 {
   "validFrom":"2007-01-02",
-  "validUntil":"2020-01-01",
+  "validUntil":"2020-01-02",
   "administrativeStatus":"OPEN",
   "codes":[
     {
@@ -10,7 +10,7 @@
       "name": "Sortland - Suortá",
       "rank": "1",
       "validFromInRequestedRange": "2018-01-01",
-      "validToInRequestedRange": "2020-01-01"
+      "validToInRequestedRange": "2020-01-02"
     },
     {
       "classificationId": "131",


### PR DESCRIPTION
I fixed the logic and the junit tests to reflect that the validUntil of subset versions is not inclusive. 

It is now legal to POST and PUT versions that have a validFrom date that equals the validUntil date of a previously published version, and it is also possible to POST and PUT versions that have a validUntil that is equal to the validFrom of a previously published version.

From before, it is already the case that the validUntil date of the previous latest published subset version is automatically set to the validFrom of the new latest published version.