### PR TITLE
indent retag step to be a job rather than a task

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,3 +82,7 @@ jobs:
         parameters:
           imageName: $(imageName)
           repoName: $(repoName)
+  - template: 'docker/docker-tag-for-production.yml@templates'
+    parameters:
+      tagToTag: 'master-$(fullSha)'
+      gcrImageName: $(imageName)

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-secretmanager</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.3</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
I think i figure why the retag template didn't work. In the template it is defined as a job, so it needs to be run on the job level of the parent yaml, not on the step level.