### PR TITLE
testing, dependency upgrades

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jre
+FROM azul/zulu-openjdk-alpine:11-jre
 
 # Add the service itself
 COPY ./target/klass-subsets-api.jar /usr/share/klass-subsets-api/

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,11 @@ jobs:
           testResultsFiles: '**/TEST-*.xml'
           goals: 'install'
           options: '-DskipTests=false -Dmaven.javadoc.skip=true'
-  - template: 'docker/docker-build-image-and-push-to-gcr.yml@templates'
+      - template: 'docker/docker-build-image-and-push-to-gcr.yml@templates'
+        parameters:
+          imageName: $(imageName)
+          repoName: $(repoName)
+  - template: 'docker/docker-tag-for-production.yml@templates'
     parameters:
-      imageName: $(imageName)
-      repoName: $(repoName)
+      tagToTag: 'master-$(fullSha)'
+      gcrImageName: $(imageName)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ jobs:
           testResultsFiles: '**/TEST-*.xml'
           goals: 'install'
           options: '-DskipTests=false -Dmaven.javadoc.skip=true'
-      - template: 'docker/docker-build-image-and-push-to-gcr.yml@templates'
-        parameters:
-          imageName: $(imageName)
-          repoName: $(repoName)
+  - template: 'docker/docker-build-image-and-push-to-gcr.yml@templates'
+    parameters:
+      imageName: $(imageName)
+      repoName: $(repoName)

--- a/pom.xml
+++ b/pom.xml
@@ -114,13 +114,13 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-secretmanager</artifactId>
-            <version>1.2.6</version>
+            <version>1.2.8</version>
         </dependency>
 
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
-            <version>1.5.0</version>
+            <version>1.5.2</version>
         </dependency>
         
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>com.google.cloud</groupId>
             <artifactId>google-cloud-secretmanager</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.6</version>
         </dependency>
 
         <dependency>

--- a/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
@@ -904,7 +904,7 @@ class SubsetsControllerV2Test {
     }
 
     @Test
-    void postNewVersionThatSetsValidUntilOfPreviousVersionToOneDayBeforeValidFromOfNewVersion(){
+    void postNewVersionSetsValidUntilOfPreviousLatestVersionToSameDateAsValidFromOfNewVersion(){
         SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
         JsonNode series = readJsonFile(series_1_0);
         String seriesId = series.get(Field.ID).asText();
@@ -1406,7 +1406,7 @@ class SubsetsControllerV2Test {
     }
 
     @Test
-    void autoSetValidUntilOnPublish(){
+    void autoSetValidUntilOnPublishingDrafts(){
         SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
 
         JsonNode series = readJsonFile(series_2_0);
@@ -1447,7 +1447,7 @@ class SubsetsControllerV2Test {
     }
 
     @Test
-    void autoSetValidUntil2(){
+    void doNotPublishNewFirstVersionThatDoesNotContainValidUntil(){
         SubsetsControllerV2 instance = SubsetsControllerV2.getInstance();
 
         JsonNode series = readJsonFile(series_2_0);
@@ -1478,12 +1478,6 @@ class SubsetsControllerV2Test {
                 false,
                 "all",
                 version202Open);
-        assertEquals(HttpStatus.OK, putVersion202OpenRE.getStatusCode());
-
-        ResponseEntity<JsonNode> getVersion202RE = instance.getVersion(seriesId, putVersion202OpenRE.getBody().get(Field.VERSION_ID).asText(), "all");
-        JsonNode getVersion202REBody = getVersion202RE.getBody();
-        System.out.println(getVersion202REBody.toPrettyString());
-        assertTrue(getVersion202REBody.has(Field.VALID_UNTIL));
-        assertEquals(version203Open.get(Field.VALID_FROM), getVersion202REBody.get(Field.VALID_UNTIL));
+        assertEquals(HttpStatus.BAD_REQUEST, putVersion202OpenRE.getStatusCode());
     }
 }

--- a/src/test/resources/version_examples/version_2_0_2_draft.json
+++ b/src/test/resources/version_examples/version_2_0_2_draft.json
@@ -1,0 +1,28 @@
+{
+  "validFrom":"2007-01-01",
+  "administrativeStatus":"DRAFT",
+  "codes":[
+    {
+      "classificationId": "131",
+      "code": "1870",
+      "level": "1",
+      "name": "Sortland - Suortá",
+      "rank": "1",
+      "validFromInRequestedRange": "2018-01-01",
+      "validToInRequestedRange": null
+    },
+    {
+      "classificationId": "131",
+      "code": "1870",
+      "level": "1",
+      "name": "Sortland",
+      "rank": "1",
+      "validFromInRequestedRange": "2007-01-01",
+      "validToInRequestedRange": "2018-01-01"
+    }
+  ],
+  "versionRationale": [
+    {"languageCode":"nb", "languageText":"versjon rasjonale 2 på norsk bokmål"},
+    {"languageCode":"en", "languageText":"version rationale 2 in english"}
+  ]
+}

--- a/src/test/resources/version_examples/version_2_0_3_draft.json
+++ b/src/test/resources/version_examples/version_2_0_3_draft.json
@@ -1,0 +1,19 @@
+{
+  "validFrom":"2020-01-02",
+  "administrativeStatus":"DRAFT",
+  "codes":[
+    {
+      "classificationId": "131",
+      "code": "1870",
+      "level": "1",
+      "name": "Sortland - Suortá",
+      "rank": "1",
+      "validFromInRequestedRange": "2020-01-02",
+      "validToInRequestedRange": null
+    }
+  ],
+  "versionRationale": [
+    {"languageCode":"nb", "languageText":"versjon rasjonale 2 på norsk bokmål"},
+    {"languageCode":"en", "languageText":"version rationale 2 in english"}
+  ]
+}


### PR DESCRIPTION
test where we submit drafts first, and then publish them one by one, checking whether validUntil of previously last version is automatically set

test where we submit drafts, and then publish the latest version first, then the previous one which lacks validUntil, and expect it to be rejected.

upgraded a couple dependencies

indent the re-tag step of the azure pipeline to be a "job" rather than a "task" (Azure terminology), which is necessary because the used template defines the work as a job.