### PR TITLE
only build images from dev, no rebuild from master

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,6 @@ trigger:
   branches:
     include:
       - 'development'
-      - 'master'
 
 pool:
   vmImage: 'ubuntu-latest'
@@ -84,5 +83,5 @@ jobs:
           repoName: $(repoName)
   - template: 'docker/docker-tag-for-production.yml@templates'
     parameters:
-      tagToTag: 'master-$(fullSha)'
+      tagToTag: 'development-$(fullSha)'
       gcrImageName: $(imageName)


### PR DESCRIPTION
The images that are run in production should be the exact same ones that have been tested in staging. Therefore, we should never re-build images when we merge to master or deploy to prod. 