### PR TITLE
Optimize nr of GET requests against KLASS API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>no.ssb</groupId>
     <artifactId>klass-subsets-api</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <name>subsets-service</name>
     <description>klass subsets REST API</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>no.ssb</groupId>
     <artifactId>klass-subsets-api</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>1.0.3-SNAPSHOT</version>
     <name>subsets-service</name>
     <description>klass subsets REST API</description>
 

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -137,13 +137,13 @@ public class Utils {
         if (editableVersion.has(Field.CODES)){
             ArrayNode codesArrayNode = (ArrayNode)editableVersion.get(Field.CODES);
             for (int i = 0; i < codesArrayNode.size(); i++) {
-                LOG.debug("Resolving code "+i+"/"+codesArrayNode.size());
+                LOG.debug("Resolving classification versions of code "+(i+1)+"/"+codesArrayNode.size());
                 JsonNode code = Utils.addCodeVersions(codesArrayNode.get(i), LOG);
                 if (code.get(Field.CLASSIFICATION_VERSIONS).size() < 1)
                     LOG.error("Code "+code.get(Field.CODE)+" "+code.get(Field.NAME)+" failed to resolve any versions in validity range "+code.get(Field.VALID_FROM_IN_REQUESTED_RANGE).asText()+" - "+(code.has(Field.VALID_TO_IN_REQUESTED_RANGE) ? code.get(Field.VALID_TO_IN_REQUESTED_RANGE).asText() : "null"));
                 codesArrayNode.set(i, code);
             }
-            LOG.debug("codesArrayNode size "+codesArrayNode.size());
+            LOG.debug("Done resolving all classification versions of all codes");
             editableVersion.set(Field.CODES, codesArrayNode);
         }
         return editableVersion;


### PR DESCRIPTION
It used to be that a POST/PUT subset version request triggered 2*3*n(codes) GET requests to KLASS, every time.

Now that scenario will only be possible in theory and with an upper bound at number of published classification versions, and the best case is 1 request to KLASS per subset version POST/PUT. Most of the time there is probably a good handful of requests, but at least there won't necessarily be 1000s of requests done for 100's of codes.

What I do to optimize the nr of requests is cashing KLASS classification version GET responses in different languages in a hashmap, that I check for names and notes of each code. If many codes in the subset version come from the same KLASS classification version (they often do), it will drastically reduce the Nr of KLASS API requests. If all the subset codes come from different KLASS classification versions, then we will have to make one request per code, as usual. This case is increasingly unlikely and even impossible when subset size increases, which is the case we're optimizing for. Thus, we have effectively eliminated the worst case scenario from before.