### PR TITLE
avoid crash in name resolution

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -1266,14 +1266,19 @@ public class SubsetsControllerV2 {
                     String validFrom = editableCode.get(Field.VALID_FROM_IN_REQUESTED_RANGE).asText();
                     String validTo = editableCode.has(Field.VALID_TO_IN_REQUESTED_RANGE) && !editableCode.get(Field.VALID_TO_IN_REQUESTED_RANGE).isNull() ? editableCode.get(Field.VALID_TO_IN_REQUESTED_RANGE).asText(): "";
                     ResponseEntity<JsonNode> getCodesFromKlassRE = KlassURNResolver.getFrom(KlassURNResolver.makeKLASSCodesFromToURL(classificationID, validFrom, validTo, code, languageCode));
-                    System.out.println(getCodesFromKlassRE.getBody().toPrettyString());
-                    ArrayNode codesFromKlassArrayNode = getCodesFromKlassRE.getBody().get(Field.CODES).deepCopy();
-                    name = codesFromKlassArrayNode.get(0).get(Field.NAME).asText();
+                    if (getCodesFromKlassRE.getStatusCode().is2xxSuccessful()){
+                        ArrayNode codesFromKlassArrayNode = getCodesFromKlassRE.getBody().get(Field.CODES).deepCopy();
+                        name = codesFromKlassArrayNode.get(0).get(Field.NAME).asText();
+                    } else {
+                        LOG.warn("Did not get 2xx Successful when trying to get Code '"+code+"' in language '"+languageCode+"' from Klass in order to retrieve the Name in that language");
+                    }
                 }
-                ObjectNode mlT = new ObjectMapper().createObjectNode();
-                mlT.put("languageCode", languageCode);
-                mlT.put("languageText", name);
-                namesArray.add(mlT);
+                if (!name.equals("")) {
+                    ObjectNode mlT = new ObjectMapper().createObjectNode();
+                    mlT.put("languageCode", languageCode);
+                    mlT.put("languageText", name);
+                    namesArray.add(mlT);
+                }
             }
             editableCode.set(Field.NAME, namesArray);
             codes.set(i, editableCode);


### PR DESCRIPTION
KLASS gives 404 if a requested code does not have a version in the language we request.

I have made it so that if we ask KLASS for a code in a language that does not exist, we simply do not create an entry for its name in the "name" array of the code as stored in the subset version. 

The question is if this might create problems down the line, where some other code expects all languages to be present, even if it's just an empty languageText. **EDIT: I think in that case we should build those systems to account for the fact that there isn't always a text for each language, so this is the best way.**  Including an empty languageText "" might cause some system down the line to think that there is a name in that language when there is not. Again, I think it's best to not include an empty string at all.