### PR TITLE
Bugfix/date comparisons

### DIFF
--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -846,7 +846,7 @@ public class SubsetsControllerV2 {
             String entryValidUntil = versionJsonNode.has(Field.VALID_UNTIL) ? versionJsonNode.get(Field.VALID_UNTIL).textValue() : null;
             String versionId = versionJsonNode.get(Field.VERSION_ID).asText();
             LOG.debug("version "+versionId+" has validFrom "+entryValidFrom+" and validUntil "+(entryValidFrom != null ? entryValidUntil : "does not exist"));
-            if (entryValidFrom.compareTo(date) <= 0 && (entryValidUntil == null || entryValidUntil.compareTo(date) >= 0)) {
+            if (entryValidFrom.compareTo(date) <= 0 && (entryValidUntil == null || entryValidUntil.compareTo(date) > 0)) {
                 LOG.debug("The date "+date+" was within the range!");
                 JsonNode codes = versionJsonNode.get(Field.CODES);
                 return new ResponseEntity<>(codes, OK);

--- a/src/main/java/no/ssb/subsetsservice/Utils.java
+++ b/src/main/java/no/ssb/subsetsservice/Utils.java
@@ -164,10 +164,10 @@ public class Utils {
             String classificationVersionValidFrom = classificationVersion.get(Field.VALID_FROM).asText();
             String classificationVersionValidUntil = classificationVersion.has("validTo") ? classificationVersion.get("validTo").asText() : null;
             LOG.debug("Classification version '"+classificationVersion.get(Field.NAME).asText()+" has validFrom "+classificationVersionValidFrom+" and validTo "+(classificationVersionValidUntil != null ? classificationVersionValidUntil : "null"));
-            if (validUntilInRequestedRange == null || classificationVersionValidFrom.compareTo(validUntilInRequestedRange) <= 0) {
+            if (validUntilInRequestedRange == null || classificationVersionValidFrom.compareTo(validUntilInRequestedRange) < 0) {
                 LOG.debug("Classification version '"+classificationVersion.get(Field.NAME).asText()+" had validFrom before the validUntilInRequestedRange of the code");
-                if (classificationVersionValidUntil == null || classificationVersionValidUntil.compareTo(validFromInRequestedRange) >= 0) {
-                    LOG.debug("Classification version '"+classificationVersion.get(Field.NAME).asText()+" had a classificationVersionValidUntil == null || classificationVersionValidUntil.compareTo(validFromInRequestedRange) >= 0 ");
+                if (classificationVersionValidUntil == null || classificationVersionValidUntil.compareTo(validFromInRequestedRange) > 0) {
+                    LOG.debug("Classification version '"+classificationVersion.get(Field.NAME).asText()+" had a classificationVersionValidUntil == null || classificationVersionValidUntil.compareTo(validFromInRequestedRange) > 0 ");
                     String codeVersionURL = classificationVersion.get(Field._LINKS).get(Field.SELF).get("href").asText();
                     classificationVersionLinksArrayNode.add(codeVersionURL);
                 }


### PR DESCRIPTION
@rsassb found and pointed out one erroneous date range check. In Utils at line 167-170, a validUntil date has to be strictly **AFTER** a validFrom date in order for there to be overlap between the two ranges, because validUntil dates are not inclusive.

I also found another completely unrelated error of the same type at line 849 of SubsetsControllerV2, because I decided to look for similar errors while I was at it: The validUntil of a range has to be AFTER the date in order for the date to be inside the range.