### PR TITLE
fix bug reported by BA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.12</version>
+            <version>1.18.20</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -772,13 +772,13 @@ public class SubsetsControllerV2 {
 
         ArrayNode codesInRangeArrayNode = new ObjectMapper().createArrayNode();
 
-        for (String s : classificationVersionsMap.keySet()) {
-            Set<String> classificationVersionSet = classificationVersionsMap.get(s);
+        for (Map.Entry<String, Set<String>> entry : classificationVersionsMap.entrySet()) {
+            Set<String> classificationVersionSet = entry.getValue();
             ArrayNode classificationVersionList = new ObjectMapper().createArrayNode();
             classificationVersionSet.forEach(classificationVersionList::add); // duplicate free classificationVersionList
 
             ObjectNode editableCode = new ObjectMapper().createObjectNode();
-            String[] splitUnderscore = s.split("_");
+            String[] splitUnderscore = entry.getKey().split("_");
             String classificationId = splitUnderscore[0];
             String code = splitUnderscore[1];
             String name = splitUnderscore[2];

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -709,6 +709,9 @@ public class SubsetsControllerV2 {
             }
         }
 
+        if (language == null || language.isEmpty())
+            language="nb";
+
         // If a date interval is specified using 'from' and/or 'to' query parameters
         ResponseEntity<JsonNode> getAllVersionsRE = getVersions(id, includeFuture, includeDrafts, language);
         if (!getAllVersionsRE.getStatusCode().equals(OK))

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -747,11 +747,9 @@ public class SubsetsControllerV2 {
         }
 
         // The point of this is that no two codes with the same name, code and level should be added twice to the list
-        // AND classification versions should not be duplicated in the list
-
+        // AND classification versions should not be duplicated in the classificationVersionList
 
         Map<String, Set<String>> classificationVersionsMap = new HashMap<>();
-        Map<String, JsonNode> codeNodeMap = new HashMap<>();
 
         for (JsonNode subsetVersion : versionsValidInDateRange) {
             LOG.debug("Version " + subsetVersion.get(Field.VERSION_ID) + " is valid in the interval, so its codes will be included");

--- a/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
+++ b/src/main/java/no/ssb/subsetsservice/SubsetsControllerV2.java
@@ -709,19 +709,18 @@ public class SubsetsControllerV2 {
             }
         }
 
-        // If a date interval is specified using 'from' and 'to' query parameters
+        // If a date interval is specified using 'from' and/or 'to' query parameters
         ResponseEntity<JsonNode> getAllVersionsRE = getVersions(id, includeFuture, includeDrafts, language);
         if (!getAllVersionsRE.getStatusCode().equals(OK))
             return getAllVersionsRE;
         JsonNode allVersionsArrayNode = getAllVersionsRE.getBody();
         LOG.debug(String.format("Getting valid codes of subset %s from date %s to date %s", id, from, to));
-        ObjectMapper mapper = new ObjectMapper();
         Map<String, ArrayNode> codeMap = new HashMap<>();
 
         if (allVersionsArrayNode == null)
             return ErrorHandler.newHttpError("Response body was null", INTERNAL_SERVER_ERROR, LOG);
         if (!allVersionsArrayNode.isArray())
-            return ErrorHandler.newHttpError("Response body was null", INTERNAL_SERVER_ERROR, LOG);
+            return ErrorHandler.newHttpError("Response body was not array", INTERNAL_SERVER_ERROR, LOG);
 
         ArrayNode versionsValidInDateRange = (ArrayNode) allVersionsArrayNode;
         int nrOfVersions = versionsValidInDateRange.size();
@@ -752,7 +751,7 @@ public class SubsetsControllerV2 {
             for (JsonNode codeJsonNode : codesArrayNode) {
                 String classificationId = codeJsonNode.get(Field.CLASSIFICATION_ID).asText();
                 String code = codeJsonNode.get(Field.CODE).asText();
-                String name = codeJsonNode.get(Field.NAME).asText();
+                String name = codeJsonNode.get(Field.NAME).toString();
                 String level = codeJsonNode.get(Field.LEVEL).asText();
                 String codeURN = classificationId+"_"+code+"_"+name+"_"+level;
                 ArrayNode classificationVersionsArrayNode = codeJsonNode.get(Field.CLASSIFICATION_VERSIONS).deepCopy();

--- a/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
+++ b/src/test/java/no/ssb/subsetsservice/SubsetsControllerV2Test.java
@@ -1377,8 +1377,9 @@ class SubsetsControllerV2Test {
         System.out.println();
         ArrayNode getCodesFromToREBody = getCodesFromToRE.getBody().deepCopy();
         System.out.println(getCodesFromToREBody.toPrettyString());
-        assertEquals(1, getCodesFromToREBody.size());
-        assertEquals(10, getCodesFromToREBody.get(0).get(Field.CLASSIFICATION_VERSIONS).size());
+        assertEquals(2, getCodesFromToREBody.size());
+        assertEquals(7, getCodesFromToREBody.get(0).get(Field.CLASSIFICATION_VERSIONS).size());
+        assertEquals(3, getCodesFromToREBody.get(1).get(Field.CLASSIFICATION_VERSIONS).size());
     }
 
     @Test


### PR DESCRIPTION
- BUG: When using the "codes?from=/to=" api call, the names of codes are empty.
  - I believe this is the fix.

- I had to edit one of my unit tests because the unit test was wrong

- I also wrote a different solution for avoiding duplicates in the "classification version list", using a Set data structure.