### PR TITLE
add schemas to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM azul/zulu-openjdk-alpine:11-jre
 
 # Add the service itself
 COPY ./target/klass-subsets-api.jar /usr/share/klass-subsets-api/
+COPY ./src/main/resources/definitions/series.json /usr/share/klass-subsets-api/
+COPY ./src/main/resources/definitions/version.json /usr/share/klass-subsets-api/
 
 ENTRYPOINT ["java", "-jar", "/usr/share/klass-subsets-api/klass-subsets-api.jar"]
 


### PR DESCRIPTION
subsets-api in staging is failing because it can't find the schema files. That's because they are not included in the Docker image.

The schema files will now be copied into the Docker image.

When running, subsets-api will dynamically find the schema files. It will check for the files at the project folder location (where they are found during development) and then at the location they will be found when running in the Docker container. If it doesn't find them in either location, subsets-api will throw an error.